### PR TITLE
FHIR Resource Fields validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 # Keep environment variables out of version control
 .env
+
+output.txt

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off"
+      }
     }
   },
   "javascript": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "zod": "^3.24.2"
   },
   "dependencies": {
+    "@fastify/multipart": "^9.0.3",
     "@prisma/client": "^6.6.0",
     "axios": "^1.8.4",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^16.5.0",
     "fastify-zod": "^1.4.0",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@fastify/multipart':
+        specifier: ^9.0.3
+        version: 9.0.3
       '@prisma/client':
         specifier: ^6.6.0
         version: 6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3)
-      '@types/stream-json':
-        specifier: ^1.7.8
-        version: 1.7.8
       axios:
         specifier: ^1.8.4
         version: 1.8.4
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.1.0)
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -51,6 +54,9 @@ importers:
       '@types/papaparse':
         specifier: ^5.3.15
         version: 5.3.15
+      '@types/stream-json':
+        specifier: ^1.7.8
+        version: 1.7.8
       fastify:
         specifier: ^5.3.0
         version: 5.3.0
@@ -279,6 +285,12 @@ packages:
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
 
+  '@fastify/busboy@3.1.1':
+    resolution: {integrity: sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==}
+
+  '@fastify/deepmerge@2.0.2':
+    resolution: {integrity: sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==}
+
   '@fastify/error@4.1.0':
     resolution: {integrity: sha512-KeFcciOr1eo/YvIXHP65S94jfEEqn1RxTRBT1aJaHxY5FK0/GDXYozsQMMWlZoHgi8i0s+YtrLsgj/JkUUjSkQ==}
 
@@ -290,6 +302,9 @@ packages:
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/multipart@9.0.3':
+    resolution: {integrity: sha512-pJogxQCrT12/6I5Fh6jr3narwcymA0pv4B0jbC7c6Bl9wnrxomEUnV0d26w6gUls7gSXmhG8JGRMmHFIPsxt1g==}
 
   '@fastify/proxy-addr@5.0.0':
     resolution: {integrity: sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==}
@@ -605,6 +620,14 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -1057,6 +1080,9 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  secure-json-parse@3.0.2:
+    resolution: {integrity: sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==}
+
   secure-json-parse@4.0.0:
     resolution: {integrity: sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==}
 
@@ -1377,6 +1403,10 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.17.1)
       fast-uri: 3.0.6
 
+  '@fastify/busboy@3.1.1': {}
+
+  '@fastify/deepmerge@2.0.2': {}
+
   '@fastify/error@4.1.0': {}
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
@@ -1388,6 +1418,14 @@ snapshots:
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
+
+  '@fastify/multipart@9.0.3':
+    dependencies:
+      '@fastify/busboy': 3.1.1
+      '@fastify/deepmerge': 2.0.2
+      '@fastify/error': 4.1.0
+      fastify-plugin: 5.0.1
+      secure-json-parse: 3.0.2
 
   '@fastify/proxy-addr@5.0.0':
     dependencies:
@@ -1709,6 +1747,12 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  date-fns-tz@3.2.0(date-fns@4.1.0):
+    dependencies:
+      date-fns: 4.1.0
+
+  date-fns@4.1.0: {}
 
   debug@4.4.0:
     dependencies:
@@ -2188,6 +2232,8 @@ snapshots:
       ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
+
+  secure-json-parse@3.0.2: {}
 
   secure-json-parse@4.0.0: {}
 

--- a/prisma/database/seeds/seed.ts
+++ b/prisma/database/seeds/seed.ts
@@ -6,47 +6,170 @@ async function main() {
 	console.log('Start seeding ...');
 
 	// URLs Canônicas (ajuste conforme necessário ou processe as SDs primeiro)
-	const brCorePatientUrl =
-		'https://br-core.saude.gov.br/fhir/StructureDefinition/br-core-patient';
+	const brCorePatientUrl = 'http://localhost:8080/fhir/StructureDefinition/1';
 	const observationBaseUrl =
 		'http://hl7.org/fhir/StructureDefinition/Observation';
-	const patientBaseUrl = 'http://hl7.org/fhir/StructureDefinition/Patient'; // URL da SD base do Patient
+	const administrativeGenderVs =
+		'http://hl7.org/fhir/ValueSet/administrative-gender';
 
-	// --- Mapeamento CSV -> Patient (TO_FHIR) ---
-	// Validado contra br-core-patient OU Patient base se br-core não processado
 	await prisma.mappingConfiguration.upsert({
 		where: { name: 'CsvToPatientBasic' },
-		update: { structureDefinitionUrl: brCorePatientUrl }, // Tenta validar contra o perfil BR
+		update: { structureDefinitionUrl: brCorePatientUrl },
 		create: {
-			name: 'CsvToPatientBasic',
+			name: 'CsvMapping',
 			description: 'Maps a simple CSV to FHIR Patient resource',
 			sourceType: SourceType.CSV,
 			fhirResourceType: 'Patient',
 			direction: Direction.TO_FHIR,
-			structureDefinitionUrl: brCorePatientUrl, // Especifica contra qual SD validar
+			structureDefinitionUrl: brCorePatientUrl,
 			fieldMappings: {
 				create: [
-					// Paths relativos à raiz do Patient
-					{ sourcePath: 'id_paciente', targetFhirPath: 'id' },
-					{ sourcePath: 'nome_completo', targetFhirPath: 'name[0].text' }, // Mapeia para o primeiro nome, campo text
 					{
-						sourcePath: 'nome_oficial',
-						targetFhirPath: "name[?use='official'].text",
-					}, // Exemplo: Mapeando para nome oficial
-					{ sourcePath: 'data_nascimento', targetFhirPath: 'birthDate' },
-					{ sourcePath: 'genero', targetFhirPath: 'gender' },
-					{ sourcePath: 'cpf', targetFhirPath: 'identifier[0].value' }, // Mapeamento simples para valor do primeiro identificador
-					{ sourcePath: 'cpf_system', targetFhirPath: 'identifier[0].system' }, // Ex: 'urn:oid:2.16.840.1.113883.13.236' (oid do CPF)
-					{ sourcePath: 'cpf_use', targetFhirPath: 'identifier[0].use' }, // Ex: 'official'
-					{ sourcePath: 'ativo', targetFhirPath: 'active' }, // Ex: true/false no CSV
+						sourcePath: 'id_paciente',
+						targetFhirPath: 'id',
+						validationType: 'REQUIRED',
+					},
+					{
+						sourcePath: 'nome_completo',
+						targetFhirPath: 'name[0].text',
+						validationType: 'MIN_LENGTH',
+						validationDetails: { min: 3 },
+					},
+					{
+						sourcePath: 'data_nascimento',
+						targetFhirPath: 'birthDate',
+						validationType: 'REGEX',
+						validationDetails: {
+							pattern: '^\\d{2}/\\d{2}/\\d{4}$',
+							message: 'Formato esperado DD/MM/YYYY',
+						},
+						transformationType: 'FORMAT_DATE',
+						transformationDetails: {
+							inputFormat: 'dd/MM/yyyy',
+							outputFormat: 'yyyy-MM-dd',
+						},
+					},
+					{
+						sourcePath: 'genero',
+						targetFhirPath: 'gender', // Ex: M, F, I no CSV
+						transformationType: 'CODE_LOOKUP',
+						transformationDetails: {
+							map: { M: 'male', F: 'female', I: 'other' },
+							defaultValue: 'unknown',
+						},
+						validationType: 'VALUESET', // Valida o valor *transformado* (male, female, other, unknown)
+						validationDetails: {
+							valueSetUrl: administrativeGenderVs,
+							strength: 'required',
+						},
+					},
+					{
+						sourcePath: 'cpf',
+						targetFhirPath: 'identifier[0].value',
+						validationType: 'REGEX',
+						validationDetails: {
+							pattern: '^\\d{11}$',
+							message: 'CPF deve ter 11 dígitos',
+						},
+					},
 				],
 			},
 		},
 	});
 	console.log('Upserted mapping: CsvToPatientBasic');
 
-	// --- Mapeamento JSON -> Observation (TO_FHIR) ---
-	// Validado contra a Observation base
+	await prisma.mappingConfiguration.upsert({
+		where: { name: 'ExampleJsonToPatient' },
+		update: { structureDefinitionUrl: brCorePatientUrl },
+		create: {
+			name: 'ExampleJsonToPatient',
+			description:
+				'Example mapping from a custom JSON structure to FHIR Patient (BR Core Profile)',
+			sourceType: SourceType.JSON,
+			fhirResourceType: 'Patient',
+			direction: Direction.TO_FHIR,
+			structureDefinitionUrl: brCorePatientUrl,
+			fieldMappings: {
+				create: [
+					{
+						sourcePath: 'pacienteIdInterno',
+						targetFhirPath: 'id',
+						validationType: 'REQUIRED',
+					},
+					{
+						sourcePath: 'cpf',
+						targetFhirPath: 'identifier[0].value',
+						validationType: 'REGEX',
+						validationDetails: {
+							pattern: '^\\d{11}$',
+							message: 'CPF deve ter 11 dígitos numéricos',
+						},
+					},
+					{
+						sourcePath: 'nomeCompleto',
+						targetFhirPath: 'name[0].text',
+						validationType: 'REQUIRED',
+					},
+					{
+						sourcePath: 'dataNascimento', // Esperado no formato dd/MM/yyyy
+						targetFhirPath: 'birthDate',
+						validationType: 'REGEX',
+						validationDetails: { pattern: '^\\d{2}/\\d{2}/\\d{4}$' },
+						transformationType: 'FORMAT_DATE',
+						transformationDetails: {
+							inputFormat: 'dd/MM/yyyy',
+							outputFormat: 'yyyy-MM-dd',
+						},
+					},
+					{
+						sourcePath: 'sexo', // Esperado "M", "F", "I"
+						targetFhirPath: 'gender',
+						transformationType: 'CODE_LOOKUP',
+						transformationDetails: {
+							map: { M: 'male', F: 'female', I: 'other' },
+							defaultValue: 'unknown',
+						},
+						validationType: 'VALUESET', // Valida 'male', 'female', 'other', 'unknown'
+						validationDetails: { valueSetUrl: administrativeGenderVs },
+					},
+					// --- Ativo ---
+					{
+						sourcePath: 'statusAtivo', // Esperado true/false
+						targetFhirPath: 'active',
+						// Se a entrada fosse "S"/"N", usaria CODE_LOOKUP para true/false
+					},
+					{
+						sourcePath: 'contatos[0].telefone',
+						targetFhirPath: 'telecom[0].value',
+					},
+					{
+						sourcePath: 'contatos[1].email',
+						targetFhirPath: 'telecom[1].value',
+					},
+					// --- Extensão Raça/Cor (Exemplo - baseado no perfil BR) ---
+					// Supondo que br-core-patient define a extensão de raça/cor
+					// e que ela tenha um elemento 'valueCodeableConcept.coding[0].code'
+					// e 'valueCodeableConcept.coding[0].system' com valor fixo.
+					// E a extensão principal tem url 'http://www.saude.gov.br/fhir/r4/StructureDefinition/BRRacaCorEtnia-1.0'
+					// E a sub-extensão 'race' tem url 'race' relativa à extensão principal.
+					{
+						sourcePath: 'codigoRacaCor', // Ex: "01" (Branca), "02" (Preta), etc.
+						targetFhirPath:
+							"extension[?url='http://www.saude.gov.br/fhir/r4/StructureDefinition/BRRacaCorEtnia-1.0'].extension[?url='race'].valueCodeableConcept.coding[0].code",
+					},
+					// O system da raça/cor provavelmente é um fixedValue no perfil da extensão, então não mapearíamos.
+					// Se não fosse, seria:
+					// {
+					//   targetFhirPath: "extension[?url='http://www.saude.gov.br/fhir/r4/StructureDefinition/BRRacaCorEtnia-1.0'].extension[?url='race'].valueCodeableConcept.coding[0].system",
+					//   transformationType: "DEFAULT_VALUE",
+					//   transformationDetails: { value: "http://www.saude.gov.br/fhir/r4/CodeSystem/BRRacaCor" }
+					// }
+				],
+			},
+		},
+	});
+	console.log('Upserted mapping: ExampleJsonToPatient');
+
 	await prisma.mappingConfiguration.upsert({
 		where: { name: 'JsonToObservationVitals' },
 		update: { structureDefinitionUrl: observationBaseUrl },
@@ -59,7 +182,6 @@ async function main() {
 			structureDefinitionUrl: observationBaseUrl,
 			fieldMappings: {
 				create: [
-					// Paths relativos à raiz da Observation
 					{ sourcePath: 'vitalSign.id', targetFhirPath: 'id' },
 					{ sourcePath: 'vitalSign.status', targetFhirPath: 'status' },
 					{
@@ -73,7 +195,7 @@ async function main() {
 					{
 						sourcePath: 'vitalSign.codeSystem',
 						targetFhirPath: 'code.coding[0].system',
-					}, // Ex: 'http://loinc.org'
+					},
 					{
 						sourcePath: 'vitalSign.value',
 						targetFhirPath: 'valueQuantity.value',
@@ -85,79 +207,120 @@ async function main() {
 					{
 						sourcePath: 'vitalSign.valueSystem',
 						targetFhirPath: 'valueQuantity.system',
-					}, // Ex: 'http://unitsofmeasure.org'
+					},
 					{
 						sourcePath: 'vitalSign.effectiveDateTime',
 						targetFhirPath: 'effectiveDateTime',
 					},
-					{ sourcePath: 'patientId', targetFhirPath: 'subject.reference' }, // Ex: 'Patient/123'
+					{ sourcePath: 'patientId', targetFhirPath: 'subject.reference' },
 				],
 			},
 		},
 	});
 	console.log('Upserted mapping: JsonToObservationVitals');
 
-	// --- Mapeamento Patient -> CSV (FROM_FHIR) ---
-	// Valida os campos FHIR lidos contra br-core-patient OU Patient base
-	await prisma.mappingConfiguration.upsert({
-		where: { name: 'PatientToCsvBasic' },
-		update: { structureDefinitionUrl: brCorePatientUrl },
-		create: {
-			name: 'PatientToCsvBasic',
-			description: 'Maps FHIR Patient resources to a simple CSV',
-			sourceType: SourceType.CSV, // Target é CSV
-			fhirResourceType: 'Patient', // Source é Patient
-			direction: Direction.FROM_FHIR,
-			structureDefinitionUrl: brCorePatientUrl, // Valida os paths FHIR lidos
-			fieldMappings: {
-				create: [
-					// targetFhirPath é relativo ao recurso Patient lido
-					{ targetFhirPath: 'id', sourcePath: 'patient_identifier' }, // Coluna CSV 'patient_identifier'
-					{ targetFhirPath: 'name[0].text', sourcePath: 'full_name' }, // Pega texto do primeiro nome
-					{ targetFhirPath: 'birthDate', sourcePath: 'dob' },
-					{ targetFhirPath: 'gender', sourcePath: 'sex' },
-					{ targetFhirPath: 'address[0].city', sourcePath: 'city' }, // Pega cidade do primeiro endereço
-					{ targetFhirPath: 'active', sourcePath: 'is_active' },
-				],
-			},
-		},
-	});
-	console.log('Upserted mapping: PatientToCsvBasic');
+	// await prisma.mappingConfiguration.upsert({
+	// 	where: { name: 'PatientToCsvBasic' },
+	// 	update: { structureDefinitionUrl: brCorePatientUrl },
+	// 	create: {
+	// 		name: 'PatientToCsvBasic',
+	// 		description: 'Maps FHIR Patient resources to a simple CSV',
+	// 		sourceType: SourceType.CSV,
+	// 		fhirResourceType: 'Patient',
+	// 		direction: Direction.FROM_FHIR,
+	// 		structureDefinitionUrl: brCorePatientUrl,
+	// 		fieldMappings: {
+	// 			create: [
+	// 				{
+	// 					targetFhirPath: 'id',
+	// 					sourcePath: 'patient_identifier',
+	// 					validationType: 'REQUIRED',
+	// 				},
+	// 				{
+	// 					targetFhirPath: 'name[0].text',
+	// 					sourcePath: 'full_name',
+	// 					validationType: 'MIN_LENGTH',
+	// 					validationDetails: { min: 3 },
+	// 				},
+	// 				{
+	// 					targetFhirPath: 'birthDate',
+	// 					sourcePath: 'dob',
+	// 					validationType: 'REGEX',
+	// 					validationDetails: {
+	// 						pattern: '^\\d{2}/\\d{2}/\\d{4}$',
+	// 						message: 'Formato esperado DD/MM/YYYY',
+	// 					},
+	// 					transformationType: 'FORMAT_DATE',
+	// 					transformationDetails: {
+	// 						inputFormat: 'dd/MM/yyyy',
+	// 						outputFormat: 'yyyy-MM-dd',
+	// 					},
+	// 				},
+	// 				{
+	// 					targetFhirPath: 'gender',
+	// 					sourcePath: 'sex',
+	// 					transformationType: 'CODE_LOOKUP',
+	// 					transformationDetails: {
+	// 						map: { M: 'male', F: 'female', I: 'other' },
+	// 						defaultValue: 'unknown',
+	// 					},
+	// 					validationType: 'VALUESET', // Valida o valor *transformado* (male, female, other, unknown)
+	// 					validationDetails: {
+	// 						valueSetUrl: administrativeGenderVs,
+	// 						strength: 'required',
+	// 					}, // Valida contra o ValueSet padrão FHIR
+	// 				},
+	// 				{
+	// 					sourcePath: 'cpf',
+	// 					targetFhirPath:
+	// 						"identifier[?system='urn:oid:2.16.840.1.113883.13.236'].value", // Mapeando especificamente para o identificador CPF
+	// 					validationType: 'REGEX',
+	// 					validationDetails: {
+	// 						pattern: '^\\d{11}$',
+	// 						message: 'CPF deve ter 11 dígitos',
+	// 					},
+	// 					// Adicionar REQUIRED
+	// 				},
+	// 			],
+	// 		},
+	// 	},
+	// });
+	// console.log('Upserted mapping: PatientToCsvBasic');
 
-	// --- Mapeamento Observation -> JSON (FROM_FHIR) ---
-	// Valida os campos FHIR lidos contra Observation base
-	await prisma.mappingConfiguration.upsert({
-		where: { name: 'ObservationToJsonBasic' },
-		update: { structureDefinitionUrl: observationBaseUrl },
-		create: {
-			name: 'ObservationToJsonBasic',
-			description: 'Maps FHIR Observation resources to simple JSON objects',
-			sourceType: SourceType.JSON, // Target é JSON
-			fhirResourceType: 'Observation', // Source é Observation
-			direction: Direction.FROM_FHIR,
-			structureDefinitionUrl: observationBaseUrl, // Valida os paths FHIR lidos
-			fieldMappings: {
-				create: [
-					// targetFhirPath é relativo ao recurso Observation lido
-					{ targetFhirPath: 'id', sourcePath: 'obsId' }, // Gera campo obsId no JSON de saída
-					{ targetFhirPath: 'status', sourcePath: 'currentStatus' },
-					{
-						targetFhirPath: 'code.coding[0].code',
-						sourcePath: 'measurement.code',
-					},
-					{
-						targetFhirPath: 'code.coding[0].display',
-						sourcePath: 'measurement.name',
-					},
-					{ targetFhirPath: 'valueQuantity.value', sourcePath: 'result.value' },
-					{ targetFhirPath: 'valueQuantity.unit', sourcePath: 'result.units' },
-					{ targetFhirPath: 'effectiveDateTime', sourcePath: 'timestamp' },
-					{ targetFhirPath: 'subject.reference', sourcePath: 'patientRef' },
-				],
-			},
-		},
-	});
-	console.log('Upserted mapping: ObservationToJsonBasic');
+	// // --- Mapeamento Observation -> JSON (FROM_FHIR) ---
+	// // Valida os campos FHIR lidos contra Observation base
+	// await prisma.mappingConfiguration.upsert({
+	// 	where: { name: 'ObservationToJsonBasic' },
+	// 	update: { structureDefinitionUrl: observationBaseUrl },
+	// 	create: {
+	// 		name: 'ObservationToJsonBasic',
+	// 		description: 'Maps FHIR Observation resources to simple JSON objects',
+	// 		sourceType: SourceType.JSON, // Target é JSON
+	// 		fhirResourceType: 'Observation', // Source é Observation
+	// 		direction: Direction.FROM_FHIR,
+	// 		structureDefinitionUrl: observationBaseUrl, // Valida os paths FHIR lidos
+	// 		fieldMappings: {
+	// 			create: [
+	// 				// targetFhirPath é relativo ao recurso Observation lido
+	// 				{ targetFhirPath: 'id', sourcePath: 'obsId' }, // Gera campo obsId no JSON de saída
+	// 				{ targetFhirPath: 'status', sourcePath: 'currentStatus' },
+	// 				{
+	// 					targetFhirPath: 'code.coding[0].code',
+	// 					sourcePath: 'measurement.code',
+	// 				},
+	// 				{
+	// 					targetFhirPath: 'code.coding[0].display',
+	// 					sourcePath: 'measurement.name',
+	// 				},
+	// 				{ targetFhirPath: 'valueQuantity.value', sourcePath: 'result.value' },
+	// 				{ targetFhirPath: 'valueQuantity.unit', sourcePath: 'result.units' },
+	// 				{ targetFhirPath: 'effectiveDateTime', sourcePath: 'timestamp' },
+	// 				{ targetFhirPath: 'subject.reference', sourcePath: 'patientRef' },
+	// 			],
+	// 		},
+	// 	},
+	// });
+	// console.log('Upserted mapping: ObservationToJsonBasic');
 
 	console.log('Seeding finished.');
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,8 +30,10 @@ model FieldMapping {
   id                     String               @id @default(cuid())
   sourcePath             String
   targetFhirPath         String
-  transformationType     String?
+  transformationType     TransformationType?
   transformationDetails  Json?
+  validationType         ValidationType?
+  validationDetails      Json?
   defaultValue           String?
   mappingConfigurationId String
   mappingConfiguration   MappingConfiguration @relation(fields: [mappingConfigurationId], references: [id], onDelete: Cascade)
@@ -94,4 +96,46 @@ enum SourceType {
 enum Direction {
   TO_FHIR
   FROM_FHIR
+}
+
+enum ValidationType {
+  REGEX
+  RANGE
+  REQUIRED
+  OPTIONAL
+  FIXED
+  DEFAULT
+  CUSTOM
+  MIN_LENGTH
+  MAX_LENGTH
+  PATTERN
+  ENUM
+  DATE
+  TIME
+  DATETIME
+  BOOLEAN
+  INTEGER
+  FLOAT
+  STRING
+  URI
+  CODE
+  DECIMAL
+  VALUESET
+}
+
+enum TransformationType {
+  MAP
+  FILTER
+  REDUCE
+  FLATTEN
+  SPLIT
+  JOIN
+  MERGE
+  CONCATENATE
+  TRIM
+  LOWERCASE
+  UPPERCASE
+  FORMAT_DATE
+  PARSE_DATE
+  CODE_LOOKUP
 }

--- a/src/lib/fastify.ts
+++ b/src/lib/fastify.ts
@@ -1,7 +1,16 @@
+import fastifyMultipart from '@fastify/multipart';
 import sensible from '@fastify/sensible';
 import Fastify, { type FastifyInstance } from 'fastify';
+import { ZodError } from 'zod';
 import { appRoutes } from '../routes';
 import { schemas } from '../schemas';
+import { FhirClientError } from '../services/errors/FhirClientError';
+import { InvalidInputDataError } from '../services/errors/InvalidInputDataError';
+import { InvalidMappingError } from '../services/errors/InvalidMappingError';
+import { MappingConfigurationNotFoundError } from '../services/errors/MappingConfigurationNotFoundError';
+import { MultipartRequestError } from '../services/errors/MultipartRequestError';
+import { StructureDefinitionNotProcessedError } from '../services/errors/StructureDefinitionNotProcessedError';
+import '../utils/transformation';
 
 export function buildServer(): FastifyInstance {
 	const app = Fastify({
@@ -9,11 +18,67 @@ export function buildServer(): FastifyInstance {
 	});
 
 	app.register(sensible);
-	app.addContentTypeParser('text/csv', (request, payload, done) => {
-		done(null);
+	app.register(fastifyMultipart);
+
+	app.setErrorHandler((error, _, reply) => {
+		if (error instanceof ZodError) {
+			return reply.status(400).send({
+				statusCode: 400,
+				success: false,
+				message: 'Validation error.',
+				issues: error.flatten().fieldErrors,
+			});
+		}
+
+		if (error.validation) {
+			return reply.status(400).send({
+				statusCode: 400,
+				success: false,
+				message: 'Validation error.',
+				errors: error.message,
+			});
+		}
+
+		if (error instanceof MappingConfigurationNotFoundError) {
+			return reply
+				.status(404)
+				.send({ statusCode: 404, success: false, message: error.message });
+		}
+
+		if (
+			error instanceof InvalidInputDataError ||
+			error instanceof InvalidMappingError ||
+			error instanceof MultipartRequestError
+		) {
+			return reply
+				.status(400)
+				.send({ statusCode: 400, success: false, message: error.message });
+		}
+
+		if (error instanceof FhirClientError) {
+			return reply
+				.status(502)
+				.send({ statusCode: 502, success: false, message: error.message });
+		}
+
+		if (error instanceof StructureDefinitionNotProcessedError) {
+			return reply
+				.status(422)
+				.send({ statusCode: 422, success: false, message: error.message });
+		}
+
+		app.log.error(error);
+
+		// Erro genérico para o cliente
+		return reply.status(500).send({
+			statusCode: 500,
+			success: false,
+			message: 'Internal server error.',
+		});
 	});
+
 	for (const schema of schemas) app.addSchema(schema);
-	app.register(appRoutes, { prefix: '/api' });
+	app.register(appRoutes, { prefix: '/api/v1' });
 
 	return app;
 }

--- a/src/repositories/structure-definitions/create-many-elements.ts
+++ b/src/repositories/structure-definitions/create-many-elements.ts
@@ -1,0 +1,10 @@
+import type { Prisma } from '@prisma/client';
+import { db } from '../../lib/prisma';
+
+export async function createManyElementStructureDefinitions(
+	elements: Prisma.FhirElementDefinitionCreateManyInput[],
+): Promise<Prisma.FhirElementDefinitionCreateManyInput[]> {
+	return await db.fhirElementDefinition.createManyAndReturn({
+		data: elements,
+	});
+}

--- a/src/repositories/structure-definitions/delete-many-elements.ts
+++ b/src/repositories/structure-definitions/delete-many-elements.ts
@@ -1,0 +1,9 @@
+import { db } from '../../lib/prisma';
+
+export async function deleteManyElementStructureDefinitions(
+	id: string,
+): Promise<void> {
+	await db.fhirElementDefinition.deleteMany({
+		where: { structureDefinitionId: id },
+	});
+}

--- a/src/repositories/structure-definitions/find-many.ts
+++ b/src/repositories/structure-definitions/find-many.ts
@@ -1,0 +1,6 @@
+import { db } from '../../lib/prisma';
+
+export async function findManyStructureDefinitions() {
+	const structureDefinitions = await db.fhirStructureDefinition.findMany({});
+	return structureDefinitions;
+}

--- a/src/repositories/structure-definitions/find-unique-sd.ts
+++ b/src/repositories/structure-definitions/find-unique-sd.ts
@@ -1,0 +1,17 @@
+import { db } from '../../lib/prisma';
+import type { FhirStructureDefinitionWithPaths } from '../../types/StructureDefinition';
+
+export async function findUniqueStructureDefinitionByUrlOrType(
+	url?: string | null,
+	type?: string | null,
+): Promise<FhirStructureDefinitionWithPaths | null> {
+	return await db.fhirStructureDefinition.findFirst({
+		where: {
+			OR: [...(url ? [{ url }] : []), ...(type ? [{ type }] : [])],
+		},
+		include: { elements: { select: { path: true } } },
+		orderBy: {
+			processedAt: 'desc',
+		},
+	});
+}

--- a/src/repositories/structure-definitions/find-unique-sd.ts
+++ b/src/repositories/structure-definitions/find-unique-sd.ts
@@ -9,9 +9,65 @@ export async function findUniqueStructureDefinitionByUrlOrType(
 		where: {
 			OR: [...(url ? [{ url }] : []), ...(type ? [{ type }] : [])],
 		},
-		include: { elements: { select: { path: true } } },
+		include: { elements: true },
 		orderBy: {
 			processedAt: 'desc',
 		},
+	});
+}
+
+export async function findMandatoryStructureDefinitionByUrlOrType(
+	url?: string | null,
+	type?: string | null,
+): Promise<FhirStructureDefinitionWithPaths | null> {
+	const sd = await db.fhirStructureDefinition.findFirst({
+		where: {
+			OR: [...(url ? [{ url }] : []), ...(type ? [{ type }] : [])],
+		},
+		include: {
+			elements: {
+				where: {
+					cardinalityMin: { gte: 1 },
+					OR: [{ fixedValue: { not: null } }, { defaultValue: { not: null } }],
+				},
+			},
+		},
+	});
+
+	return sd;
+}
+
+export async function findFirstMandatoryStructureDefinitionByUrlOrType(
+	url?: string | null,
+	type?: string | null,
+): Promise<FhirStructureDefinitionWithPaths | null> {
+	const sd = await db.fhirStructureDefinition.findFirst({
+		where: {
+			OR: [...(url ? [{ url }] : []), ...(type ? [{ type }] : [])],
+		},
+		include: {
+			elements: {
+				where: { cardinalityMin: { gte: 1 } },
+			},
+		},
+	});
+
+	return sd;
+}
+
+export async function findElementsWithFixedOrDefaultValue(
+	url?: string | null,
+	type?: string | null,
+): Promise<FhirStructureDefinitionWithPaths | null> {
+	return db.fhirStructureDefinition.findFirst({
+		where: { OR: [...(url ? [{ url }] : []), ...(type ? [{ type }] : [])] },
+		include: {
+			elements: {
+				where: {
+					OR: [{ fixedValue: { not: null } }, { defaultValue: { not: null } }],
+				},
+			},
+		},
+		orderBy: { processedAt: 'desc' },
 	});
 }

--- a/src/repositories/structure-definitions/transaction.ts
+++ b/src/repositories/structure-definitions/transaction.ts
@@ -1,0 +1,33 @@
+import type { Prisma } from '@prisma/client';
+import { db } from '../../lib/prisma';
+
+export async function fhirStructureDefinitionTransaction(
+	url: string,
+	data: Prisma.FhirStructureDefinitionCreateInput,
+	elementsData: Omit<
+		Prisma.FhirElementDefinitionCreateManyInput,
+		'structureDefinitionId'
+	>[],
+) {
+	return await db.$transaction(async (tx) => {
+		const upsertedSd = await tx.fhirStructureDefinition.upsert({
+			where: { url },
+			update: { ...data, processedAt: new Date() }, // Atualiza data de processamento
+			create: data,
+		});
+		await tx.fhirElementDefinition.deleteMany({
+			where: { structureDefinitionId: upsertedSd.id },
+		});
+		if (elementsData.length > 0) {
+			const elementsToCreate = elementsData.map((el) => ({
+				...el,
+				structureDefinitionId: upsertedSd.id,
+			}));
+			await tx.fhirElementDefinition.createMany({
+				data: elementsToCreate,
+				skipDuplicates: true, // Ignora duplicatas silenciosamente se @@unique falhar por algum motivo
+			});
+		}
+		return upsertedSd;
+	});
+}

--- a/src/repositories/structure-definitions/upsert-sd.ts
+++ b/src/repositories/structure-definitions/upsert-sd.ts
@@ -1,0 +1,15 @@
+import type { Prisma } from '@prisma/client';
+import { db } from '../../lib/prisma';
+
+export async function upsertStructureDefinition(
+	url: string,
+	data: Prisma.FhirStructureDefinitionCreateInput,
+): Promise<Prisma.FhirStructureDefinitionCreateInput> {
+	const upsertedSd = await db.fhirStructureDefinition.upsert({
+		where: { url },
+		update: { ...data, processedAt: new Date() }, // Atualiza data de processamento
+		create: data,
+	});
+
+	return upsertedSd;
+}

--- a/src/routes/structure-definition.routes.ts
+++ b/src/routes/structure-definition.routes.ts
@@ -1,6 +1,48 @@
 import type { FastifyInstance } from 'fastify';
-import { handleProcessStructureDefinition } from '../controllers/structure-definition.controller';
+import {
+	handleGetStructureDefinition,
+	handleGetUniqueStructureDefinition,
+	handleProcessStructureDefinition,
+} from '../controllers/structure-definition.controller';
+import { $ref } from '../schemas/structure-definition.schema';
 
 export async function structureDefinitionRoutes(app: FastifyInstance) {
-	app.post('/', {}, handleProcessStructureDefinition);
+	app.get(
+		'/',
+		{
+			schema: {
+				tags: ['StructureDefinition'],
+				summary: 'Get StructureDefinitions',
+				description:
+					'Retrieves all StructureDefinitions stored in the database.',
+			},
+		},
+		handleGetStructureDefinition,
+	);
+	app.post(
+		'/search',
+		{
+			schema: {
+				tags: ['StructureDefinition'],
+				summary: 'Get a StructureDefinition by URL or Type',
+				description:
+					'Retrieves a StructureDefinition by its URL or Type from the database.',
+				body: $ref('getUniqueStructureDefinitionSchema'),
+			},
+		},
+		handleGetUniqueStructureDefinition,
+	);
+	app.post(
+		'/',
+		{
+			schema: {
+				tags: ['StructureDefinition'],
+				summary: 'Process a StructureDefinition',
+				description:
+					'Processes a StructureDefinition from a FHIR server and stores it in the database.',
+				body: $ref('processStructureDefinitionSchema'),
+			},
+		},
+		handleProcessStructureDefinition,
+	);
 }

--- a/src/routes/transform.routes.ts
+++ b/src/routes/transform.routes.ts
@@ -1,6 +1,27 @@
 import type { FastifyInstance } from 'fastify';
-import { handleTransformRequest } from '../controllers/transform.controller';
+import {
+	handleTransformByFile,
+	handleTransformRequest,
+} from '../controllers/transform.controller';
+import { $ref } from '../schemas/transform.schema';
 
 export async function transformRoutes(app: FastifyInstance) {
-	app.post('/', {}, handleTransformRequest);
+	app.post(
+		'/',
+		{
+			schema: {
+				body: $ref('transformBodySchema'),
+			},
+		},
+		handleTransformRequest,
+	);
+	app.post(
+		'/file',
+		{
+			schema: {
+				consumes: ['multipart/form-data'],
+			},
+		},
+		handleTransformByFile,
+	);
 }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,3 +1,4 @@
+import { structureDefinitionSchemas } from './structure-definition.schema';
 import { transformSchemas } from './transform.schema';
 
-export const schemas = [...transformSchemas];
+export const schemas = [...transformSchemas, ...structureDefinitionSchemas];

--- a/src/schemas/structure-definition.schema.ts
+++ b/src/schemas/structure-definition.schema.ts
@@ -1,9 +1,10 @@
+import { buildJsonSchemas } from 'fastify-zod';
 import { z } from 'zod';
 
 export const processStructureDefinitionSchema = z.object({
 	identifier: z
 		.string({
-			required_error: 'StructureDefinition identifier (ID or URL) is required',
+			message: 'StructureDefinition identifier (ID or URL) is required',
 		})
 		.min(1),
 	fhirServerUrl: z
@@ -12,6 +13,26 @@ export const processStructureDefinitionSchema = z.object({
 		.optional(),
 });
 
+export const getUniqueStructureDefinitionSchema = z
+	.object({
+		url: z.string().url().optional(),
+		type: z.string().optional(),
+	})
+	.refine((data) => data.url || data.type, {
+		message: 'Either url or type must be provided',
+	});
+
 export type ProcessStructureDefinitionBody = z.infer<
 	typeof processStructureDefinitionSchema
 >;
+export type GetUniqueStructureDefinitionParams = z.infer<
+	typeof getUniqueStructureDefinitionSchema
+>;
+
+export const { schemas: structureDefinitionSchemas, $ref } = buildJsonSchemas(
+	{
+		processStructureDefinitionSchema,
+		getUniqueStructureDefinitionSchema,
+	},
+	{ $id: 'structureDefinitionSchemas' },
+);

--- a/src/schemas/transform.schema.ts
+++ b/src/schemas/transform.schema.ts
@@ -1,30 +1,73 @@
 import { buildJsonSchemas } from 'fastify-zod';
+import { Readable } from 'node:stream';
 import { z } from 'zod';
 
-export const transformRequestBodySchema = z.object({
+export const transformBodySchema = z.object({
 	mappingConfigName: z
 		.string()
-		.min(1, { message: 'Mapping config name is required' }),
-	data: z.any(),
-	sendToFhirServer: z.boolean().optional().default(false),
-	fhirServerUrlOverride: z.string().url().optional(),
+		.min(1, { message: 'Voce deve informar o nome do mapeamento.' }),
+
+	sendToFhirServer: z
+		.union([z.boolean(), z.string()])
+		.transform((val) =>
+			typeof val === 'string' ? val.toLowerCase() === 'true' : val,
+		)
+		.optional()
+		.default(false),
+
+	fhirServerUrlOverride: z
+		.string()
+		.url({ message: 'URL incorreta para fhirServerUrlOverride.' })
+		.optional()
+		.nullable()
+		.or(z.literal('')), // Permite nulo ou string vazia
+
+	fhirQueryPath: z.string().optional().nullable(), // Para FROM_FHIR
+	data: z
+		.array(
+			z.record(z.unknown(), {
+				description: 'Objeto JSON de entrada para ser transformado.',
+			}),
+		)
+		.min(1, { message: 'A lista de dados não pode estar vazia.' }),
 });
 
-export const transformApiSchema = z.object({
+export const transformFileSchema = z.object({
 	mappingConfigName: z
-		.string({ required_error: 'mappingConfigName is required' })
-		.min(1),
-	sendToFhirServer: z.boolean().optional().default(false),
-	fhirServerUrlOverride: z.string().url().optional(),
-	fhirQueryPath: z.string().optional(), // Obrigatório para FROM_FHIR (validado no serviço)
+		.string({ message: 'Voce deve informar o nome do mapeamento.' })
+		.min(1, { message: 'Voce deve informar o nome do mapeamento.' }),
+
+	sendToFhirServer: z
+		.union([z.boolean(), z.string()])
+		.transform((val) =>
+			typeof val === 'string' ? val.toLowerCase() === 'true' : val,
+		)
+		.optional()
+		.default(false),
+
+	fhirServerUrlOverride: z
+		.string()
+		.url({ message: 'URL incorreta para fhirServerUrlOverride.' })
+		.optional()
+		.nullable()
+		.or(z.literal('')), // Permite nulo ou string vazia
+
+	fhirQueryPath: z
+		.string({ message: 'Informe o path de busca no servidor FHIR.' })
+		.optional()
+		.nullable(), // Para FROM_FHIR
+	file: z.instanceof(Readable, {
+		message: 'O arquivo deve ser um stream legível.',
+	}),
 });
 
-export type TransformRequestBody = z.infer<typeof transformRequestBodySchema>;
-export type TransformApiParams = z.infer<typeof transformApiSchema>;
+export type TransformBodyParams = z.infer<typeof transformBodySchema>;
+export type TransformFileParams = z.infer<typeof transformFileSchema>;
 
 export const { schemas: transformSchemas, $ref } = buildJsonSchemas(
 	{
-		transformRequestBodySchema,
+		transformBodySchema,
+		transformFileSchema,
 	},
 	{ $id: 'transformSchemas' },
 );

--- a/src/services/errors/MultipartRequestError.ts
+++ b/src/services/errors/MultipartRequestError.ts
@@ -1,0 +1,9 @@
+export class MultipartRequestError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'MultipartRequestError';
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, MultipartRequestError);
+		}
+	}
+}

--- a/src/services/fhir.fetch.service.ts
+++ b/src/services/fhir.fetch.service.ts
@@ -1,18 +1,11 @@
-// src/services/fhir.fetch.service.ts
 import axios from 'axios';
 import { Readable } from 'node:stream';
+import type { FhirResourceStreamOptions } from '../types/FhirResource';
 import { FhirClientError } from './errors/FhirClientError';
 
 const DEFAULT_FHIR_SERVER_URL =
 	process.env.FHIR_SERVER_BASE_URL || 'http://localhost:8080/fhir';
-const DEFAULT_PAGE_SIZE = 50; // Ajustar conforme necessidade/capacidade do servidor
-
-interface FhirResourceStreamOptions {
-	initialUrl: string;
-	fhirServerUrl?: string;
-	pageSize?: number;
-	// TODO: Adicionar opções de autenticação se necessário
-}
+const DEFAULT_PAGE_SIZE = 50;
 
 export class FhirResourceStream extends Readable {
 	private fhirBaseUrl: string;
@@ -20,7 +13,7 @@ export class FhirResourceStream extends Readable {
 	private fetching: boolean;
 	private pageSize: number;
 	private resourceQueue: any[];
-	private totalFetched = 0; // Contador para debug
+	private totalFetched = 0;
 
 	constructor(options: FhirResourceStreamOptions) {
 		super({
@@ -128,18 +121,20 @@ export class FhirResourceStream extends Readable {
 					Accept: 'application/fhir+json',
 					// TODO: Adicionar headers de autenticação
 				},
-				timeout: 60000, // Aumenta timeout para busca
+				timeout: 60000,
 			});
 
 			const bundle = response.data;
 
 			if (bundle?.resourceType === 'Bundle' && Array.isArray(bundle.entry)) {
-				bundle.entry.forEach(
-					(entry: any) =>
-						entry.resource && this.resourceQueue.push(entry.resource),
-				);
+				for (const entry of bundle.entry) {
+					if (entry.resource) {
+						this.resourceQueue.push(entry.resource);
+					}
+				}
 				const nextLink = bundle.link?.find(
-					(link: any) => link.relation === 'next',
+					(link: { relation: string; url?: string }) =>
+						link.relation === 'next',
 				);
 				if (nextLink?.url) {
 					this.nextPageUrl = nextLink.url;

--- a/src/services/fhir.fetch.service.ts
+++ b/src/services/fhir.fetch.service.ts
@@ -25,15 +25,24 @@ export class FhirResourceStream extends Readable {
 
 		try {
 			// Garante que a URL inicial seja válida e inclua _count e _format
+			// Corrige para garantir que o /fhir do base não seja ignorado
+			let initialPath = options.initialUrl;
+			if (initialPath.startsWith('/')) {
+				initialPath = initialPath.slice(1); // remove barra inicial
+			}
 			const initialUrlObj = new URL(
-				options.initialUrl,
+				initialPath,
 				this.fhirBaseUrl.endsWith('/')
 					? this.fhirBaseUrl
 					: `${this.fhirBaseUrl}/`,
 			);
+
+			console.log('initialUrlObj', initialUrlObj);
+
 			initialUrlObj.searchParams.set('_count', String(this.pageSize));
 			initialUrlObj.searchParams.set('_format', 'json');
 			this.nextPageUrl = initialUrlObj.toString();
+			console.log('this.nextPageUrl', this.nextPageUrl);
 		} catch (e: any) {
 			console.error(
 				`FhirResourceStream: Invalid initial URL provided: ${options.initialUrl}`,
@@ -116,6 +125,7 @@ export class FhirResourceStream extends Readable {
 		// console.log(`FhirResourceStream: Fetching page: ${urlToFetch}`);
 
 		try {
+			console.log('urlToFetch', urlToFetch);
 			const response = await axios.get(urlToFetch, {
 				headers: {
 					Accept: 'application/fhir+json',

--- a/src/services/mapping.service.ts
+++ b/src/services/mapping.service.ts
@@ -1,10 +1,27 @@
+import {
+	Direction,
+	type FhirElementDefinition,
+	type Prisma,
+} from '@prisma/client';
 import { getMappingConfigurationByName } from '../repositories/mapping/getMappingConfiguration';
 import { findUniqueStructureDefinitionByUrlOrType } from '../repositories/structure-definitions/find-unique-sd';
 import type { FhirStructureDefinitionWithPaths } from '../types/StructureDefinition';
 import { isValidFhirPath } from '../utils/fhirPath';
+import { parseFhirStoredValue } from '../utils/parseFhirStored';
 import { InvalidMappingError } from './errors/InvalidMappingError';
 import { MappingConfigurationNotFoundError } from './errors/MappingConfigurationNotFoundError';
 import { StructureDefinitionNotProcessedError } from './errors/StructureDefinitionNotProcessedError';
+
+type ElementDefinitionForValidation = Pick<
+	FhirElementDefinition,
+	| 'path'
+	| 'cardinalityMin'
+	| 'fixedValue'
+	| 'fixedValueType'
+	| 'defaultValue'
+	| 'defaultValueType'
+	| 'dataTypes'
+>;
 
 export async function getMappingByNameService(name: string) {
 	const mappingConfig = await getMappingConfigurationByName(name);
@@ -34,42 +51,115 @@ export async function getMappingByNameService(name: string) {
 		!targetStructureDefinition ||
 		targetStructureDefinition.elements.length === 0
 	) {
-		// Se a URL foi especificada mas não encontrada/processada, lança erro específico
-		if (mappingConfig.structureDefinitionUrl) {
-			throw new StructureDefinitionNotProcessedError(
-				mappingConfig.structureDefinitionUrl,
-			);
-		}
-		// Se usou o tipo base e não encontrou/processou, lança erro mais genérico
-		throw new StructureDefinitionNotProcessedError(
-			`Base StructureDefinition for type '${mappingConfig.fhirResourceType}'`,
-		);
+		const id =
+			mappingConfig.structureDefinitionUrl ||
+			`type '${mappingConfig.fhirResourceType}'`;
+		throw new StructureDefinitionNotProcessedError(id);
 	}
 
-	// 4. Cria um Set com os caminhos válidos
-	const validFhirPaths = new Set(
-		targetStructureDefinition.elements.map((el) => el.path),
+	const allElementsFromSD: ElementDefinitionForValidation[] =
+		targetStructureDefinition.elements as ElementDefinitionForValidation[];
+	const relativeValidPathsFromSD = new Set<string>(
+		allElementsFromSD.map((el) =>
+			el.path.startsWith(`${mappingConfig.fhirResourceType}.`)
+				? el.path.substring(mappingConfig.fhirResourceType.length + 1)
+				: el.path,
+		),
 	);
-	// console.debug(`Validating mapping '${name}' against ${validFhirPaths.size} paths from SD '${targetStructureDefinition.url}'`);
 
-	// 5. Valida cada FieldMapping
+	// Validação 1: Paths mapeados pelo usuário devem existir na SD
 	for (const fieldMapping of mappingConfig.fieldMappings) {
-		// Valida sempre o targetFhirPath
-		const pathToValidate = fieldMapping.targetFhirPath;
+		const userMappedPath = fieldMapping.targetFhirPath;
 
-		if (!isValidFhirPath(pathToValidate, validFhirPaths)) {
-			console.error(
-				`Mapping validation failed for configuration '${mappingConfig.name}': Path '${pathToValidate}' is invalid according to SD '${targetStructureDefinition.url}'.`,
-			);
+		if (!isValidFhirPath(userMappedPath, relativeValidPathsFromSD)) {
 			throw new InvalidMappingError(
 				mappingConfig.name,
-				pathToValidate,
+				`Path '${userMappedPath}'`,
 				targetStructureDefinition.url,
 			);
 		}
+
+		// Validação 2: Usuário NÃO DEVE mapear campos que têm fixedValue na SD
+		// (A menos que seja um DEFAULT_VALUE transformation para o mesmo valor, o que é redundante)
+		const fullPathInSD = `${mappingConfig.fhirResourceType}.${userMappedPath.split('[')[0]}`;
+		const elementDefForUserPath = allElementsFromSD.find(
+			(el) =>
+				el.path === fullPathInSD || el.path.startsWith(`${fullPathInSD}:`), // Considera slices e base
+		);
+
+		if (elementDefForUserPath && elementDefForUserPath.fixedValue !== null) {
+			const fixedValFromSD = parseFhirStoredValue(
+				elementDefForUserPath.fixedValue,
+				elementDefForUserPath.fixedValueType ||
+					elementDefForUserPath.dataTypes[0],
+			);
+			let userMappedValueViaDefault: any;
+
+			if (
+				fieldMapping.transformationType?.toUpperCase() === 'DEFAULT_VALUE' &&
+				fieldMapping.transformationDetails
+			) {
+				userMappedValueViaDefault = (
+					fieldMapping.transformationDetails as Prisma.JsonObject
+				)?.value;
+			}
+
+			// Se o mapeamento não for um DEFAULT_VALUE para o mesmo valor do fixedValue, então é um problema.
+			if (
+				!(
+					fieldMapping.transformationType?.toUpperCase() === 'DEFAULT_VALUE' &&
+					userMappedValueViaDefault !== undefined &&
+					JSON.stringify(userMappedValueViaDefault) ===
+						JSON.stringify(fixedValFromSD)
+				)
+			) {
+				// MUDANÇA: Tornando isso um ERRO, conforme solicitado.
+				throw new InvalidMappingError(
+					mappingConfig.name,
+					`Path '${userMappedPath}'`,
+					targetStructureDefinition.url,
+				);
+			}
+		}
 	}
 
-	// console.debug(`Mapping '${name}' validated successfully.`);
-	// 6. Retorna a configuração validada
+	if (mappingConfig.direction === Direction.TO_FHIR) {
+		// Validação 3: Para TO_FHIR, garantir que campos obrigatórios (sem fixedValue na SD) sejam mapeados
+		const mandatoryElementsInSD = allElementsFromSD.filter(
+			(el) => (el.cardinalityMin ?? 0) >= 1 && el.fixedValue === null, // Foco em obrigatórios que NÃO têm valor fixo pelo perfil
+		);
+
+		for (const mandatoryElement of mandatoryElementsInSD) {
+			const relativeMandatoryPath = mandatoryElement.path.startsWith(
+				`${mappingConfig.fhirResourceType}.`,
+			)
+				? mandatoryElement.path.substring(
+						mappingConfig.fhirResourceType.length + 1,
+					)
+				: mandatoryElement.path;
+
+			if (
+				!relativeMandatoryPath ||
+				mandatoryElement.path === mappingConfig.fhirResourceType
+			)
+				continue; // Pula o próprio elemento raiz
+
+			const baseMandatoryPath = relativeMandatoryPath.split('[')[0];
+			const isMappedByUser = mappingConfig.fieldMappings.some((fm) =>
+				fm.targetFhirPath.startsWith(baseMandatoryPath),
+			);
+
+			// Se é obrigatório, não tem fixedValue, e o usuário não mapeou,
+			// verificamos se tem um defaultValue na SD. Se também não tiver defaultValue, é um erro.
+			if (!isMappedByUser && mandatoryElement.defaultValue === null) {
+				throw new InvalidMappingError(
+					mappingConfig.name,
+					`Mandatory element '${relativeMandatoryPath}'`,
+					targetStructureDefinition.url,
+				);
+			}
+		}
+	}
+	// console.log(`Mapping '${name}' and its field paths validated successfully against SD '${targetStructureDefinition.url}'.`);
 	return mappingConfig;
 }

--- a/src/services/parser.service.ts
+++ b/src/services/parser.service.ts
@@ -1,10 +1,10 @@
-import { Transform } from 'node:stream';
+import { type Duplex, Transform } from 'node:stream';
 import Papa from 'papaparse';
 import { parser } from 'stream-json';
 import { streamValues } from 'stream-json/streamers/StreamValues';
-import { InvalidInputDataError } from './transform.service';
+import { InvalidInputDataError } from './errors/InvalidInputDataError';
 
-export function createCsvParserStream(): Transform {
+export function createCsvParserStream(): Duplex {
 	return Papa.parse(Papa.NODE_STREAM_INPUT, {
 		header: true,
 		skipEmptyLines: true,
@@ -19,7 +19,7 @@ export function createJsonParserStream(): Transform {
 
 	const objectExtractor = new Transform({
 		objectMode: true,
-		transform({ key, value }, encoding, callback) {
+		transform({ key, value }, _, callback) {
 			this.push(value);
 			callback();
 		},

--- a/src/services/structure-definition.service.ts
+++ b/src/services/structure-definition.service.ts
@@ -1,5 +1,7 @@
 import type { Prisma } from '@prisma/client';
 import axios from 'axios';
+import { findManyStructureDefinitions } from '../repositories/structure-definitions/find-many';
+import { findUniqueStructureDefinitionByUrlOrType } from '../repositories/structure-definitions/find-unique-sd';
 import { fhirStructureDefinitionTransaction } from '../repositories/structure-definitions/transaction';
 import { FhirClientError } from './errors/FhirClientError';
 
@@ -14,6 +16,22 @@ interface ProcessResult {
 	structureDefinitionUrl?: string;
 }
 
+export async function getAllStructureDefinitions() {
+	const structureDefinitions = await findManyStructureDefinitions();
+	return structureDefinitions;
+}
+
+export async function getStructureDefinitionByUrlOrType(
+	url?: string | null,
+	type?: string | null,
+) {
+	const structureDefinition = await findUniqueStructureDefinitionByUrlOrType(
+		url,
+		type,
+	);
+	return structureDefinition;
+}
+
 export async function processAndStoreStructureDefinition(
 	identifier: string,
 	fhirServerUrl?: string,
@@ -26,7 +44,7 @@ export async function processAndStoreStructureDefinition(
 		// Tenta buscar por ID ou URL canônica
 		if (identifier.includes('/')) {
 			// Heurística: Se tem /, provavelmente é URL ou tipo/id
-			if (identifier.startsWith('http')) {
+			if (identifier.startsWith('https') || identifier.startsWith('http')) {
 				// URL Canônica
 				fetchUrl = `${serverUrl}/StructureDefinition?url=${encodeURIComponent(identifier)}`;
 			} else {

--- a/src/services/transform.service.ts
+++ b/src/services/transform.service.ts
@@ -2,23 +2,34 @@ import {
 	Direction,
 	type FieldMapping,
 	type MappingConfiguration,
+	type Prisma,
 	SourceType,
 } from '@prisma/client';
-import { type Readable, Transform } from 'node:stream';
-import { sendResourceToFhirServer } from '../lib/fhir.client';
+import _ from 'lodash';
+import { type Duplex, type Readable, Transform } from 'node:stream';
 import { getMappingConfigurationByName } from '../repositories/mapping/getMappingConfiguration';
+import {
+	findElementsWithFixedOrDefaultValue,
+	findFirstMandatoryStructureDefinitionByUrlOrType,
+	findUniqueStructureDefinitionByUrlOrType,
+} from '../repositories/structure-definitions/find-unique-sd';
+import type { FieldProcessingError } from '../types/FieldProcessing';
 import type {
+	StreamItemError,
 	StreamTransformResult,
 	StreamTransformServiceParams,
 } from '../types/StreamTransform';
 import { getValue } from '../utils/getValueByPath';
-import { setValue } from '../utils/setValueByPath';
-import { FhirClientError } from './errors/FhirClientError';
+import { parseFhirStoredValue } from '../utils/parseFhirStored';
+import { type SdElement, setValue } from '../utils/setValueByPath';
+import {
+	transformationRegistry,
+	validationRegistry,
+} from '../utils/transformation';
 import { InvalidInputDataError } from './errors/InvalidInputDataError';
 import { createFhirResourceStream } from './fhir.fetch.service';
 import {
 	createCsvParserStream,
-	createCsvStringifyStream,
 	createJsonParserStream,
 	createNdjsonStringifyStream,
 } from './parser.service';
@@ -31,124 +42,119 @@ export async function streamTransformData({
 	sendToFhir = false,
 	fhirServerUrlOverride,
 }: StreamTransformServiceParams): Promise<StreamTransformResult> {
-	// 1. Obter e VALIDAR a configuração de mapeamento (getMappingConfigurationByName agora valida)
-	// Se a validação falhar aqui, um erro (InvalidMappingError ou StructureDefinitionNotProcessedError) será lançado.
 	const mappingConfig = await getMappingConfigurationByName(mappingConfigName);
 
-	// --- Variáveis do Pipeline ---
 	let initialStream: Readable;
-	let parserStream: Transform | null = null;
-	let transformStream: Transform;
-	let outputStream: Transform;
+	let parserStream: Duplex | null = null;
+	let transformStreamInstance: Transform;
+	let outputSerializerStream: Transform;
 	let outputContentType: string;
 
-	// 2. Configurar o Pipeline baseado na Direção
 	if (mappingConfig?.direction === Direction.TO_FHIR) {
-		// --- TO_FHIR: inputStream -> parser -> transformer -> serializer ---
-		if (!inputStream || !sourceContentType) {
+		if (!inputStream) {
+			// sourceContentType é verificado pelo controller agora
 			throw new InvalidInputDataError(
-				'Input stream and source content type are required for TO_FHIR direction.',
+				'Input stream is required for TO_FHIR direction when no inline data is provided.',
 			);
 		}
 		initialStream = inputStream;
 
-		if (sourceContentType.includes('csv')) {
-			if (mappingConfig.sourceType !== SourceType.CSV)
+		// O controller define sourceContentType. O parser é escolhido com base nele.
+		if (sourceContentType?.includes('csv')) {
+			if (mappingConfig?.sourceType !== SourceType.CSV)
 				throw new InvalidInputDataError(
-					`Mapping '${mappingConfigName}' expects ${mappingConfig.sourceType} but received CSV.`,
+					`Mapping '${mappingConfigName}' expects ${mappingConfig?.sourceType} but received CSV stream.`,
 				);
 			parserStream = createCsvParserStream();
 		} else if (
-			sourceContentType.includes('json') ||
-			sourceContentType.includes('ndjson')
+			sourceContentType?.includes('json') ||
+			sourceContentType?.includes('ndjson')
 		) {
-			if (mappingConfig.sourceType !== SourceType.JSON)
+			if (mappingConfig?.sourceType !== SourceType.JSON)
 				throw new InvalidInputDataError(
-					`Mapping '${mappingConfigName}' expects ${mappingConfig.sourceType} but received JSON/NDJSON.`,
+					`Mapping '${mappingConfigName}' expects ${mappingConfig?.sourceType} but received JSON/NDJSON stream.`,
 				);
 			parserStream = createJsonParserStream();
 		} else {
+			// Este caso pode não ser alcançado se o controller validar Content-Type antes
 			throw new InvalidInputDataError(
-				`Unsupported source Content-Type for TO_FHIR: ${sourceContentType}. Use 'text/csv' or 'application/json'/'application/x-ndjson'.`,
+				`Unsupported source Content-Type for TO_FHIR stream: ${sourceContentType}.`,
 			);
 		}
 
-		transformStream = createFhirTransformStream(
+		transformStreamInstance = createFhirTransformStream(
 			mappingConfig,
 			sendToFhir,
-			fhirServerUrlOverride,
+			fhirServerUrlOverride ?? undefined,
 		);
-		outputStream = createNdjsonStringifyStream();
-		// Usar application/fhir+json pode ser enganoso para NDJSON, mas é o que muitos esperam.
-		// application/x-ndjson é mais correto tecnicamente.
-		outputContentType = 'application/fhir+json'; // Ou 'application/x-ndjson'
+		// Output is NDJSON because createFhirTransformStream emits {type:'data'/'error'} objects
+		outputSerializerStream = createNdjsonStringifyStream();
+		outputContentType = 'application/x-ndjson'; // Stream of JSON objects
 	} else if (mappingConfig?.direction === Direction.FROM_FHIR) {
-		// --- FROM_FHIR: fhirStream -> transformer -> serializer ---
 		if (!fhirQueryPath) {
 			throw new InvalidInputDataError(
 				'fhirQueryPath parameter is required for FROM_FHIR direction.',
 			);
 		}
 		parserStream = null;
-
-		console.log(`FROM_FHIR: Creating FHIR stream for query: ${fhirQueryPath}`);
 		initialStream = createFhirResourceStream({
 			initialUrl: fhirQueryPath,
-			fhirServerUrl: fhirServerUrlOverride ?? process.env.FHIR_SERVER_BASE_URL, // Usa override ou .env
+			fhirServerUrl: fhirServerUrlOverride ?? process.env.FHIR_SERVER_BASE_URL,
 		});
-
-		transformStream = createFhirTransformStream(
+		transformStreamInstance = createFhirTransformStream(
 			mappingConfig,
 			false,
 			undefined,
 		);
-
-		if (mappingConfig.sourceType === SourceType.CSV) {
-			outputStream = createCsvStringifyStream();
-			outputContentType = 'text/csv';
-		} else {
-			// Target é JSON
-			outputStream = createNdjsonStringifyStream();
-			outputContentType = 'application/x-ndjson';
-		}
+		// Output is NDJSON because createFhirTransformStream emits {type:'data'/'error'} objects
+		// The controller will take this NDJSON stream and build the final JSON response.
+		outputSerializerStream = createNdjsonStringifyStream();
+		outputContentType = 'application/x-ndjson'; // Stream of JSON objects
 	} else {
-		// Caso a direção seja inválida no banco (não deve acontecer com o enum)
 		throw new Error(
-			`Unsupported transformation direction found in mapping '${mappingConfigName}': ${mappingConfig?.direction}`,
+			`Unsupported transformation direction in mapping '${mappingConfigName}': ${mappingConfig?.direction}`,
 		);
 	}
 
-	// 3. Montar a Cadeia de Streams (Pipeline)
-	// biome-ignore lint/style/useConst: <explanation>
-	let finalOutputStream: Readable;
-	const pipelineStreams: Readable[] = [initialStream];
-	if (parserStream) pipelineStreams.push(parserStream);
-	pipelineStreams.push(transformStream);
-	pipelineStreams.push(outputStream);
+	// Monta o Pipeline
+	const allProcessStreams: (Readable | Duplex | Transform)[] = [initialStream];
+	if (parserStream) {
+		allProcessStreams.push(parserStream);
+	}
+	allProcessStreams.push(transformStreamInstance);
+	allProcessStreams.push(outputSerializerStream);
 
-	// pipeline pode lidar com array de streams
-	finalOutputStream = pipelineStreams.reduce((prev, current) =>
-		prev.pipe(current as Transform),
-	);
+	// Cria o pipeline manualmente e propaga erros para o stream final
+	let prevStream: Readable = initialStream;
+	for (let i = 1; i < allProcessStreams.length; i++) {
+		const currentStream = allProcessStreams[i];
+		// Propaga erros do stream anterior para o stream final
+		prevStream.on('error', (err) => {
+			allProcessStreams[allProcessStreams.length - 1].emit('error', err);
+		});
+		// Faz cast para Duplex | Transform, pois pipe retorna o próprio stream para esses casos
+		prevStream = prevStream.pipe(currentStream as NodeJS.WritableStream) as
+			| Duplex
+			| Transform;
+	}
 
-	// Adiciona tratamento de erro genérico para logar falhas no pipeline
+	const finalOutputStream: Readable =
+		allProcessStreams[allProcessStreams.length - 1];
+
 	finalOutputStream.on('error', (err) => {
 		console.error(
 			`STREAM PIPELINE ERROR for mapping '${mappingConfigName}':`,
-			err,
+			err?.message,
+			err?.stack,
 		);
-		// Destruir streams anteriores pode ser complexo de gerenciar aqui
-		// O importante é que o erro seja logado. O cliente receberá uma resposta interrompida.
 	});
 
-	// 4. Retornar o stream final e o content type
 	return {
 		outputStream: finalOutputStream,
 		outputContentType: outputContentType,
 	};
 }
 
-// --- Helper para criar o Transform Stream ---
 function createFhirTransformStream(
 	config: MappingConfiguration & { fieldMappings: FieldMapping[] },
 	sendToFhir: boolean,
@@ -156,129 +162,451 @@ function createFhirTransformStream(
 ): Transform {
 	return new Transform({
 		objectMode: true,
-		writableHighWaterMark: 16, // Ajustar buffer se necessário
+		writableHighWaterMark: 16,
 		readableHighWaterMark: 16,
-		async transform(chunk, _, callback) {
+		async transform(chunk, encoding, callback) {
+			const itemErrors: FieldProcessingError[] = [];
+			const sourceItem = chunk;
+			let outputItem: any = {};
+
 			try {
-				let resultItem: any = null;
-				if (config.direction === Direction.TO_FHIR) {
-					resultItem = transformSingleItemToFhir(chunk, config);
-					if (resultItem && sendToFhir) {
-						// Envio assíncrono, não espera, apenas dispara
-						sendResourceToFhirServer({
-							resource: resultItem,
-							resourceType: config.fhirResourceType,
-							fhirServerUrl: fhirServerUrlOverride,
-						})
-							.then((response) => {
-								// Log apenas se não for um OperationOutcome de erro
-								if (
-									response?.resourceType !== 'OperationOutcome' ||
-									response?.issue?.every(
-										(i: any) =>
-											i.severity === 'information' || i.severity === 'warning',
-									)
-								) {
-									console.log(
-										`FHIR Client: Async send successful for ${config.fhirResourceType}/${response?.id || '(no id)'}`,
-									);
-								} else {
-									console.warn(
-										`FHIR Client: Async send for ${config.fhirResourceType} resulted in OperationOutcome:`,
-										response.issue,
-									);
-								}
-							})
-							.catch((err) => {
-								// Logar erro do envio assíncrono
-								console.error(
-									`FHIR Client: Async send ERROR for ${config.fhirResourceType}: ${err.message}`,
-									err instanceof FhirClientError ? err.responseData : '',
-								);
-							});
+				const mappedTargetPaths = new Set<string>();
+
+				let COMPLETE_SD_ELEMENTS: SdElement[] = [];
+				const resourceTypeForElementPaths: string = config.fhirResourceType;
+
+				if (config.structureDefinitionUrl || config.fhirResourceType) {
+					const fullSdForContext =
+						await findUniqueStructureDefinitionByUrlOrType(
+							config.structureDefinitionUrl,
+							config.fhirResourceType,
+						);
+					if (fullSdForContext?.elements) {
+						COMPLETE_SD_ELEMENTS = fullSdForContext.elements.map((el) => ({
+							path: el.path,
+							max: el.cardinalityMax,
+						}));
 					}
-				} else if (config.direction === Direction.FROM_FHIR) {
-					resultItem = transformSingleItemFromFhir(chunk, config);
 				}
 
-				if (resultItem !== null) {
-					// Só envia para o próximo estágio se não for nulo
-					this.push(resultItem);
+				if (config.direction === Direction.TO_FHIR) {
+					outputItem = { resourceType: config.fhirResourceType };
+
+					if (config.structureDefinitionUrl) {
+						setValue(
+							outputItem,
+							'meta.profile[0]',
+							config.structureDefinitionUrl,
+							COMPLETE_SD_ELEMENTS,
+							resourceTypeForElementPaths,
+						);
+					}
+
+					// 1. Aplicar mapeamentos definidos pelo usuário
+					for (const mapping of config.fieldMappings) {
+						const currentPathInSource = mapping.sourcePath;
+						const currentPathInTarget = mapping.targetFhirPath;
+						if (!currentPathInTarget) continue;
+
+						const valueFromSource =
+							currentPathInSource === '$ROOT'
+								? sourceItem
+								: getValue(sourceItem, currentPathInSource);
+						let valueToSet = valueFromSource;
+						let fieldErrorFound = false;
+
+						// 1a. DEFAULT_VALUE
+						if (
+							(valueToSet === null || valueToSet === undefined) &&
+							mapping.transformationType?.toUpperCase() === 'DEFAULT_VALUE'
+						) {
+							const defaultFunc = transformationRegistry.get('DEFAULT_VALUE');
+							if (defaultFunc) {
+								const result = defaultFunc(
+									null,
+									mapping.transformationDetails,
+									{ sourceItem },
+								);
+								if (result.success) valueToSet = result.value;
+								else {
+									itemErrors.push({
+										fieldSourcePath: currentPathInSource,
+										fieldTargetPath: currentPathInTarget,
+										inputValue: valueFromSource,
+										errorType: 'Transformation',
+										message: result.message || 'Failed to apply default value',
+										details: {
+											type: 'DEFAULT_VALUE',
+											details:
+												mapping.transformationDetails as Prisma.JsonObject,
+										},
+									});
+									fieldErrorFound = true;
+								}
+							} else {
+								itemErrors.push({
+									fieldSourcePath: currentPathInSource,
+									fieldTargetPath: currentPathInTarget,
+									inputValue: valueFromSource,
+									errorType: 'Transformation',
+									message: 'DEFAULT_VALUE function not registered.',
+								});
+								fieldErrorFound = true;
+							}
+						}
+
+						// 1b. Validação
+						if (!fieldErrorFound && mapping.validationType) {
+							if (
+								mapping.validationType.toUpperCase() === 'REQUIRED' ||
+								(valueToSet !== null &&
+									valueToSet !== undefined &&
+									String(valueToSet).trim() !== '')
+							) {
+								const validationFunc = validationRegistry.get(
+									mapping.validationType.toUpperCase(),
+								);
+								if (validationFunc) {
+									const validationErrorMsg = validationFunc(
+										valueToSet,
+										mapping.validationDetails,
+										{ sourceItem },
+									);
+									if (validationErrorMsg) {
+										itemErrors.push({
+											fieldSourcePath: currentPathInSource,
+											fieldTargetPath: currentPathInTarget,
+											inputValue: valueToSet,
+											errorType: 'Validation',
+											message: validationErrorMsg,
+											details: {
+												type: mapping.validationType,
+												details: mapping.validationDetails as Prisma.JsonObject,
+											},
+										});
+										fieldErrorFound = true;
+									}
+								} else {
+									itemErrors.push({
+										fieldSourcePath: currentPathInSource,
+										fieldTargetPath: currentPathInTarget,
+										inputValue: valueToSet,
+										errorType: 'Validation',
+										message: `Validation function '${mapping.validationType}' not registered.`,
+									});
+									fieldErrorFound = true;
+								}
+							}
+						}
+
+						// 1c. Transformação
+						if (
+							!fieldErrorFound &&
+							mapping.transformationType &&
+							mapping.transformationType.toUpperCase() !== 'DEFAULT_VALUE'
+						) {
+							const transformationFunc = transformationRegistry.get(
+								mapping.transformationType.toUpperCase(),
+							);
+							if (transformationFunc) {
+								const transformResult = transformationFunc(
+									valueToSet,
+									mapping.transformationDetails,
+									{ sourceItem },
+								);
+								if (transformResult.success) valueToSet = transformResult.value;
+								else {
+									itemErrors.push({
+										fieldSourcePath: currentPathInSource,
+										fieldTargetPath: currentPathInTarget,
+										inputValue: valueToSet,
+										errorType: 'Transformation',
+										message:
+											transformResult.message ||
+											`Transformation '${mapping.transformationType}' failed.`,
+										details: {
+											type: mapping.transformationType,
+											details:
+												mapping.transformationDetails as Prisma.JsonObject,
+										},
+									});
+									fieldErrorFound = true;
+								}
+							} else {
+								itemErrors.push({
+									fieldSourcePath: currentPathInSource,
+									fieldTargetPath: currentPathInTarget,
+									inputValue: valueToSet,
+									errorType: 'Transformation',
+									message: `Transformation function '${mapping.transformationType}' not registered.`,
+								});
+								fieldErrorFound = true;
+							}
+						}
+
+						// 1d. Definir valor no outputItem
+						if (
+							!fieldErrorFound &&
+							((valueToSet !== undefined && valueToSet !== null) ||
+								(mapping.transformationType?.toUpperCase() ===
+									'DEFAULT_VALUE' &&
+									valueToSet !== undefined))
+						) {
+							if (
+								valueToSet === undefined &&
+								!(mapping.transformationType?.toUpperCase() === 'DEFAULT_VALUE')
+							) {
+								// Não setar se for undefined e não for resultado de DEFAULT_VALUE
+							} else {
+								setValue(
+									outputItem,
+									currentPathInTarget,
+									valueToSet,
+									COMPLETE_SD_ELEMENTS, // Passa a SD COMPLETA
+									resourceTypeForElementPaths,
+								);
+								mappedTargetPaths.add(currentPathInTarget.split('[')[0]);
+							}
+						}
+					}
+
+					// Início da Lógica de Auto-População (Passo 2) ---
+					// Só executa se não houver erros do Passo 1 e se tivermos informações da SD.
+					if (itemErrors.length === 0 && COMPLETE_SD_ELEMENTS.length > 0) {
+						const sdIdentifierAutoPop =
+							config.structureDefinitionUrl || config.fhirResourceType;
+						const sdInfoForAutoPopulationLoop =
+							await findElementsWithFixedOrDefaultValue(sdIdentifierAutoPop);
+
+						if (sdInfoForAutoPopulationLoop?.elements) {
+							for (const elementDef of sdInfoForAutoPopulationLoop.elements) {
+								const relativePath = elementDef.path.substring(
+									config.fhirResourceType.length + 1,
+								);
+								if (
+									!relativePath ||
+									elementDef.path === config.fhirResourceType
+								)
+									continue;
+
+								const pathBase = relativePath.split('[')[0];
+								const valueAlreadyPresent =
+									mappedTargetPaths.has(pathBase) ||
+									getValue(outputItem, relativePath) !== undefined;
+
+								if (valueAlreadyPresent) continue;
+
+								let valueToAutoSet: any;
+								if (elementDef.fixedValue !== null) {
+									valueToAutoSet = parseFhirStoredValue(
+										elementDef.fixedValue,
+										elementDef.fixedValueType || elementDef.dataTypes?.[0],
+									);
+								} else if (elementDef.defaultValue !== null) {
+									valueToAutoSet = parseFhirStoredValue(
+										elementDef.defaultValue,
+										elementDef.defaultValueType || elementDef.dataTypes?.[0],
+									);
+								}
+
+								if (valueToAutoSet !== undefined) {
+									setValue(
+										outputItem,
+										relativePath,
+										valueToAutoSet,
+										COMPLETE_SD_ELEMENTS,
+										resourceTypeForElementPaths,
+									);
+									mappedTargetPaths.add(pathBase);
+								}
+							}
+						}
+					}
+
+					// Checagem Final de Campos Obrigatórios (Passo 3) ---
+					// Só executa se não houver erros dos Passos 1 e 2 e se tivermos informações da SD.
+					if (itemErrors.length === 0 && COMPLETE_SD_ELEMENTS.length > 0) {
+						const sdIdentifierForFinalCheck =
+							config.structureDefinitionUrl || config.fhirResourceType;
+						const sdInfoForFinalCheck =
+							await findFirstMandatoryStructureDefinitionByUrlOrType(
+								sdIdentifierForFinalCheck,
+							);
+
+						if (sdInfoForFinalCheck?.elements) {
+							for (const elementDef of sdInfoForFinalCheck.elements) {
+								const relativePath = elementDef.path.substring(
+									config.fhirResourceType.length + 1,
+								);
+								if (
+									!relativePath ||
+									elementDef.path === config.fhirResourceType
+								)
+									continue;
+
+								let valueInOutput: any;
+								const pathParts = relativePath.split('.');
+								if (pathParts.length > 1) {
+									const potentialArrayPath = pathParts.slice(0, -1).join('.');
+									const propertyInArrayElement =
+										pathParts[pathParts.length - 1];
+									const arrayCandidate = getValue(
+										outputItem,
+										potentialArrayPath,
+									);
+									if (
+										Array.isArray(arrayCandidate) &&
+										arrayCandidate.length > 0
+									) {
+										valueInOutput = getValue(
+											arrayCandidate[0],
+											propertyInArrayElement,
+										);
+									} else if (
+										Array.isArray(arrayCandidate) &&
+										arrayCandidate.length === 0
+									) {
+										valueInOutput = undefined;
+									} else {
+										valueInOutput = getValue(outputItem, relativePath);
+									}
+								} else {
+									valueInOutput = getValue(outputItem, relativePath);
+								}
+
+								const isArrayActuallyEmpty =
+									Array.isArray(valueInOutput) && valueInOutput.length === 0;
+
+								if (
+									valueInOutput === undefined ||
+									valueInOutput === null ||
+									isArrayActuallyEmpty
+								) {
+									const basePathForErrorCheck = relativePath.split('[')[0];
+									if (
+										!itemErrors.some((e) =>
+											e.fieldTargetPath?.startsWith(basePathForErrorCheck),
+										)
+									) {
+										itemErrors.push({
+											fieldSourcePath: 'N/A (FHIR Profile Post-check)',
+											fieldTargetPath: relativePath,
+											inputValue:
+												valueInOutput === undefined
+													? 'undefined'
+													: JSON.stringify(valueInOutput),
+											errorType: 'Validation',
+											message: `Mandatory FHIR element '${relativePath}' (min: ${elementDef.cardinalityMin}) is missing, null, or an empty array in the final resource.`,
+											details: {
+												rule: `cardinalityMin: ${elementDef.cardinalityMin}`,
+											},
+										});
+									}
+								}
+							}
+						}
+					}
+				} else if (config.direction === Direction.FROM_FHIR) {
+					const fhirResource = sourceItem;
+					outputItem = {};
+
+					if (
+						!fhirResource ||
+						fhirResource?.resourceType !== config.fhirResourceType
+					) {
+						itemErrors.push({
+							fieldTargetPath: 'N/A',
+							inputValue: fhirResource,
+							errorType: 'Validation',
+							message: `Expected '${config.fhirResourceType}', got '${fhirResource?.resourceType}'. Skipping.`,
+						});
+					} else {
+						for (const mapping of config.fieldMappings) {
+							const currentPathInSourceFhir = mapping.targetFhirPath;
+							const currentPathInTargetSystem = mapping.sourcePath;
+							if (!currentPathInTargetSystem || !currentPathInSourceFhir)
+								continue;
+
+							const valueFromFhir = getValue(
+								fhirResource,
+								currentPathInSourceFhir,
+							);
+							const valueToSetInTarget = valueFromFhir;
+
+							if (
+								valueToSetInTarget !== undefined &&
+								valueToSetInTarget !== null
+							) {
+								if (config.sourceType === SourceType.CSV) {
+									const columnName =
+										currentPathInTargetSystem.split('.')[0] ||
+										currentPathInTargetSystem;
+									outputItem[columnName] = valueToSetInTarget;
+								} else {
+									_.set(
+										outputItem,
+										currentPathInTargetSystem,
+										valueToSetInTarget,
+									);
+								}
+							}
+						}
+					}
 				}
-				callback(); // Processamento deste chunk ok
+
+				let finalItemToPush: any = null;
+				if (config.direction === Direction.TO_FHIR) {
+					finalItemToPush = outputItem;
+				} else if (config.direction === Direction.FROM_FHIR) {
+					if (outputItem && Object.keys(outputItem).length > 0) {
+						finalItemToPush = outputItem;
+					}
+				}
+
+				if (itemErrors.length > 0) {
+					this.push({
+						type: 'error',
+						error: {
+							errors: itemErrors,
+							originalItem: sourceItem,
+						} as StreamItemError,
+					});
+				} else if (finalItemToPush) {
+					if (
+						config.direction === Direction.FROM_FHIR &&
+						Object.keys(finalItemToPush).length === 0 &&
+						!Array.isArray(finalItemToPush)
+					) {
+					} else {
+						this.push({ type: 'data', item: finalItemToPush });
+					}
+				}
+				callback();
 			} catch (error: any) {
+				const errMessage =
+					error instanceof Error ? error.message : String(error);
 				console.error(
-					'TRANSFORM STREAM ERROR:',
-					error,
-					'Failed Item (limited view):',
-					JSON.stringify(chunk).substring(0, 200),
+					`UNEXPECTED ERROR in transform for mapping '${config.name}': ${errMessage}`,
+					error.stack,
+					'Problematic Item (first 200 chars):',
+					String(sourceItem).substring(0, 200),
 				);
-				callback(error); // Propaga o erro, vai parar o pipeline
+				this.push({
+					type: 'error',
+					error: {
+						errors: [
+							{
+								fieldTargetPath: 'N/A (System Error)',
+								inputValue: sourceItem,
+								errorType: 'Transformation',
+								message: `Unexpected system error: ${errMessage}`,
+							},
+						],
+						originalItem: sourceItem,
+					} as StreamItemError,
+				});
+				callback();
 			}
 		},
 	});
-}
-
-// --- Funções de Transformação de Item Individual ---
-
-function transformSingleItemToFhir(
-	item: any,
-	config: MappingConfiguration & { fieldMappings: FieldMapping[] },
-): any {
-	// Inicia o recurso APENAS com resourceType
-	const fhirResource: any = {
-		resourceType: config.fhirResourceType,
-	};
-	// Adiciona meta.profile se a SD foi especificada no mapeamento
-	if (config.structureDefinitionUrl) {
-		setValue(fhirResource, 'meta.profile[0]', config.structureDefinitionUrl);
-	}
-
-	for (const mapping of config.fieldMappings) {
-		const sourceValue = getValue(item, mapping.sourcePath);
-
-		// Obtém o targetFhirPath CORRIGIDO (sem prefixo de tipo)
-		const targetPath = mapping.targetFhirPath; // Deve ser relativo (ex: 'id', 'name[0].text')
-
-		if (sourceValue !== undefined && sourceValue !== null && targetPath) {
-			// Define o valor usando o path relativo
-			setValue(fhirResource, targetPath, sourceValue);
-		}
-	}
-	return fhirResource;
-}
-
-function transformSingleItemFromFhir(
-	fhirResource: any,
-	config: MappingConfiguration & { fieldMappings: FieldMapping[] },
-): any {
-	const outputItem: any = {};
-
-	if (!fhirResource || fhirResource?.resourceType !== config.fhirResourceType) {
-		console.warn(
-			`FROM_FHIR: Skipping item. Expected FHIR resourceType '${config.fhirResourceType}' but got '${fhirResource?.resourceType}'.`,
-		);
-		return null; // Retorna nulo para ser filtrado no stream
-	}
-
-	for (const mapping of config.fieldMappings) {
-		const fhirPath = mapping.targetFhirPath; // Path dentro do recurso FHIR
-		const targetPath = mapping.sourcePath; // Path no JSON/CSV de saída
-
-		if (fhirPath && targetPath) {
-			const fhirValue = getValue(fhirResource, fhirPath);
-
-			if (fhirValue !== undefined && fhirValue !== null) {
-				// Se o destino for CSV, usamos apenas a primeira parte do sourcePath como chave
-				if (config.sourceType === SourceType.CSV) {
-					const columnName = targetPath.split('.')[0] || targetPath; // Pega a primeira parte
-					outputItem[columnName] = fhirValue;
-				} else {
-					// Para JSON, permite aninhar usando o sourcePath completo
-					setValue(outputItem, targetPath, fhirValue);
-				}
-			}
-		}
-	}
-	return outputItem;
 }

--- a/src/types/FhirResource.ts
+++ b/src/types/FhirResource.ts
@@ -1,0 +1,6 @@
+export interface FhirResourceStreamOptions {
+	initialUrl: string;
+	fhirServerUrl?: string;
+	pageSize?: number;
+	// TODO: Adicionar opções de autenticação se necessário
+}

--- a/src/types/FieldProcessing.ts
+++ b/src/types/FieldProcessing.ts
@@ -1,0 +1,8 @@
+export interface FieldProcessingError {
+	fieldSourcePath?: string; // Qual campo de origem falhou
+	fieldTargetPath: string; // Qual campo de destino foi afetado
+	inputValue: any; // O valor que causou o erro
+	errorType: 'Validation' | 'Transformation'; // Tipo do erro
+	message: string; // Mensagem descritiva do erro
+	details?: any; // Detalhes da regra que falhou (opcional)
+}

--- a/src/types/MappingConfig.ts
+++ b/src/types/MappingConfig.ts
@@ -1,0 +1,5 @@
+import type { FieldMapping, MappingConfiguration } from '@prisma/client';
+
+export type MappingConfigWithFields = MappingConfiguration & {
+	fieldMappings: FieldMapping[];
+};

--- a/src/types/StreamTransform.ts
+++ b/src/types/StreamTransform.ts
@@ -1,0 +1,15 @@
+import type { Readable } from 'node:stream';
+
+export interface StreamTransformServiceParams {
+	mappingConfigName: string;
+	inputStream?: Readable; // Para TO_FHIR
+	sourceContentType?: string; // Para TO_FHIR
+	fhirQueryPath?: string; // Para FROM_FHIR
+	sendToFhir?: boolean; // Apenas TO_FHIR
+	fhirServerUrlOverride?: string;
+}
+
+export interface StreamTransformResult {
+	outputStream: Readable;
+	outputContentType: string;
+}

--- a/src/types/StreamTransform.ts
+++ b/src/types/StreamTransform.ts
@@ -1,15 +1,22 @@
 import type { Readable } from 'node:stream';
+import type { FieldProcessingError } from './FieldProcessing';
 
 export interface StreamTransformServiceParams {
 	mappingConfigName: string;
 	inputStream?: Readable; // Para TO_FHIR
 	sourceContentType?: string; // Para TO_FHIR
-	fhirQueryPath?: string; // Para FROM_FHIR
+	fhirQueryPath?: string | undefined | null;
 	sendToFhir?: boolean; // Apenas TO_FHIR
-	fhirServerUrlOverride?: string;
+	fhirServerUrlOverride?: string | undefined | null;
 }
 
 export interface StreamTransformResult {
 	outputStream: Readable;
 	outputContentType: string;
+}
+
+export interface StreamItemError {
+	_isTransformError: true; // Flag para identificar erros
+	errors: FieldProcessingError[];
+	originalItem: any; // O chunk original que falhou
 }

--- a/src/types/StructureDefinition.ts
+++ b/src/types/StructureDefinition.ts
@@ -1,5 +1,8 @@
-import type { FhirStructureDefinition } from '@prisma/client';
+import type {
+	FhirElementDefinition,
+	FhirStructureDefinition,
+} from '@prisma/client';
 
 export type FhirStructureDefinitionWithPaths = FhirStructureDefinition & {
-	elements: { path: string }[];
+	elements: FhirElementDefinition[];
 };

--- a/src/types/StructureDefinition.ts
+++ b/src/types/StructureDefinition.ts
@@ -1,0 +1,5 @@
+import type { FhirStructureDefinition } from '@prisma/client';
+
+export type FhirStructureDefinitionWithPaths = FhirStructureDefinition & {
+	elements: { path: string }[];
+};

--- a/src/utils/applyTransformation.ts
+++ b/src/utils/applyTransformation.ts
@@ -1,0 +1,133 @@
+import {
+	format as formatDate,
+	isValid as isValidDate,
+	parse as parseDate,
+} from 'date-fns'; // Importa funções de date-fns
+import { getValue } from './getValueByPath';
+
+export function applyTransformation(
+	sourceValue: any,
+	type: string | null | undefined,
+	details: any | null | undefined,
+	sourceItem?: any,
+): { success: boolean; value?: any; message?: string } {
+	// 1. Lida com DEFAULT_VALUE se sourceValue for nulo/undefined
+	if (
+		(sourceValue === null || sourceValue === undefined) &&
+		type?.toUpperCase() === 'DEFAULT_VALUE'
+	) {
+		// biome-ignore lint/suspicious/noPrototypeBuiltins: <explanation>
+		if (details?.hasOwnProperty('value')) {
+			// console.log(`[Transformation] Applying DEFAULT_VALUE: ${details.value}`);
+			return { success: true, value: details.value };
+		}
+		console.warn(
+			`[Transformation] Missing 'value' in details for DEFAULT_VALUE`,
+		);
+		return { success: true, value: sourceValue }; // Retorna nulo/undefined original
+	}
+	// 2. Se não for DEFAULT_VALUE e o valor for nulo/undefined, não aplica outras transformações
+	if (sourceValue === null || sourceValue === undefined) {
+		return { success: true, value: sourceValue };
+	}
+	// 3. Se não há tipo, retorna sucesso com valor original
+	if (!type) {
+		return { success: true, value: sourceValue };
+	}
+
+	// 4. Aplica outras transformações
+	try {
+		let transformedValue: any;
+		switch (type.toUpperCase()) {
+			case 'FORMAT_DATE': {
+				if (!details?.inputFormat || !details.outputFormat)
+					return { success: false, message: 'Invalid details for DATE_FORMAT' };
+				if (typeof sourceValue !== 'string' || !sourceValue)
+					return { success: true, value: sourceValue };
+				const parsedDate = parseDate(
+					sourceValue,
+					details.inputFormat,
+					new Date(),
+				);
+				if (!isValidDate(parsedDate))
+					return {
+						success: false,
+						message: `Failed to parse date '${sourceValue}' with format '${details.inputFormat}'`,
+					};
+				transformedValue = formatDate(parsedDate, details.outputFormat);
+				break;
+			}
+
+			case 'STRING_CASE': {
+				if (typeof sourceValue !== 'string')
+					return { success: true, value: sourceValue };
+				const caseType = details?.case?.toLowerCase();
+				if (caseType === 'upper') transformedValue = sourceValue.toUpperCase();
+				else if (caseType === 'lower')
+					transformedValue = sourceValue.toLowerCase();
+				else
+					return {
+						success: false,
+						message:
+							'Invalid details for STRING_CASE (expected {case: "upper|lower"})',
+					};
+				break;
+			}
+
+			case 'CODE_LOOKUP': {
+				if (!details?.map || typeof details.map !== 'object')
+					return {
+						success: false,
+						message: 'Invalid "map" object in details for CODE_LOOKUP',
+					};
+				const mappedVal = details.map[String(sourceValue)];
+				if (mappedVal !== undefined) transformedValue = mappedVal;
+				// biome-ignore lint/suspicious/noPrototypeBuiltins: <explanation>
+				else if (details.hasOwnProperty('defaultValue'))
+					transformedValue = details.defaultValue;
+				else
+					return {
+						success: false,
+						message: `Value '${sourceValue}' not found in CODE_LOOKUP map and no defaultValue provided`,
+					};
+				break;
+			}
+
+			case 'CONCATENATE': {
+				if (
+					!details?.fieldsToConcat ||
+					!Array.isArray(details.fieldsToConcat) ||
+					!sourceItem
+				)
+					return {
+						success: false,
+						message: 'Invalid details or missing sourceItem for CONCATENATE',
+					};
+				const sep = details.separator ?? '';
+				transformedValue = details.fieldsToConcat
+					.map((fieldPath: string) =>
+						String(getValue(sourceItem, fieldPath) ?? ''),
+					)
+					.join(sep);
+				break;
+			}
+
+			// TODO: Adicionar outros cases...
+
+			default:
+				return {
+					success: false,
+					message: `Unsupported transformation type: ${type}`,
+				};
+		}
+		return { success: true, value: transformedValue }; // Retorna sucesso com valor transformado
+	} catch (error: any) {
+		console.error(
+			`[Transformation] Error applying transformation type ${type}: ${error.message}`,
+		);
+		return {
+			success: false,
+			message: `Internal error during transformation: ${error.message}`,
+		};
+	}
+}

--- a/src/utils/fhirPath.ts
+++ b/src/utils/fhirPath.ts
@@ -1,0 +1,71 @@
+/**
+ * Verifica se um determinado caminho FHIR (do mapeamento) é considerado válido
+ * em relação a um conjunto de caminhos definidos em uma StructureDefinition.
+ *
+ * @param path O caminho FHIR a ser validado (ex: 'Patient.name[0].given', 'Patient.identifier:cns.system').
+ * @param validPaths Um Set contendo todos os caminhos de elemento definidos na StructureDefinition processada (ex: 'Patient.name.given', 'Patient.identifier:cns.system').
+ * @returns true se o caminho for considerado válido, false caso contrário.
+ */
+export function isValidFhirPath(
+	path: string,
+	validPaths: Set<string>,
+): boolean {
+	console.log(`Validating path: ${path}`);
+	console.log(`Valid paths: ${Array.from(validPaths).join(', ')}`);
+
+	if (!path) {
+		// Caminho vazio ou nulo não é válido
+		return false;
+	}
+
+	// 1. Tentativa: Verifica o caminho exato
+	// Ex: 'Patient.identifier:cns.system' existe exatamente em validPaths
+	if (validPaths.has(path)) {
+		return true;
+	}
+
+	// 2. Tentativa: Simplifica removendo índices [...] e verifica novamente
+	// Ex: valida 'Patient.name[0].given' verificando se 'Patient.name.given' existe
+	const simplifiedPath = path.replace(/\[.*?\]/g, '');
+	if (path !== simplifiedPath && validPaths.has(simplifiedPath)) {
+		// console.debug(`Path '${path}' validated using simplified path '${simplifiedPath}'`);
+		return true;
+	}
+
+	// 3. Tentativa: Simplifica removendo slices ':slicename' e verifica o caminho base + sufixo
+	// Ex: valida 'Patient.identifier:cns.system' verificando se 'Patient.identifier.system' existe
+	// Isso permite mapear para um elemento dentro de uma slice se o elemento base correspondente for definido.
+	// Regex: ^(.*?)   :   ([^.]+)   \.   (.*)$
+	//       Grupo 1   :   Grupo 2   .   Grupo 3
+	//       Base Path : Slice Name . Suffix Path
+	const sliceMatch = simplifiedPath.match(/^(.*?):([^.]+)\.(.*)$/);
+	if (sliceMatch) {
+		// Recria o caminho base + sufixo (ex: Patient.identifier.system)
+		const basePathWithSuffix = `${sliceMatch[1]}.${sliceMatch[3]}`;
+		if (validPaths.has(basePathWithSuffix)) {
+			// console.debug(`Path '${path}' validated using base path '${basePathWithSuffix}' after removing slice '${sliceMatch[2]}'`);
+			return true;
+		}
+		// Tenta também validar apenas o elemento base da slice (ex: Patient.identifier)
+		// Isso pode ser útil se a própria slice for uma restrição e o elemento base for permitido.
+		const basePathOnly = sliceMatch[1];
+		if (validPaths.has(basePathOnly)) {
+			// console.debug(`Path '${path}' validated using base element path '${basePathOnly}' after removing slice '${sliceMatch[2]}'`);
+			return true;
+		}
+	}
+	// Tentativa 4: Se o path termina com :sliceName (sem sufixo), valida o path base
+	// Ex: valida Patient.identifier:cns verificando se Patient.identifier existe
+	const sliceOnlyMatch = simplifiedPath.match(/^(.*?):([^.]+)$/);
+	if (sliceOnlyMatch) {
+		const basePathOnly = sliceOnlyMatch[1];
+		if (validPaths.has(basePathOnly)) {
+			// console.debug(`Path '${path}' validated using base element path '${basePathOnly}' after removing slice '${sliceOnlyMatch[2]}'`);
+			return true;
+		}
+	}
+
+	// Se nenhuma das validações passou, o caminho é considerado inválido
+	// console.warn(`Path validation failed for: '${path}' (Simplified: '${simplifiedPath}')`);
+	return false;
+}

--- a/src/utils/getValueByPath.ts
+++ b/src/utils/getValueByPath.ts
@@ -1,10 +1,93 @@
 import _ from 'lodash';
+import { parsePathSegments } from './parsePathSegments';
+
+function getDeepFhirPathValue(
+	currentContext: any,
+	pathSegments: string[],
+	defaultValue?: any,
+): any {
+	if (currentContext === undefined || currentContext === null) {
+		return defaultValue;
+	}
+	if (pathSegments.length === 0) {
+		return currentContext;
+	}
+
+	const segmentRaw = pathSegments[0];
+	const remainingSegments = pathSegments.slice(1);
+	let nextContext: any;
+
+	if (Array.isArray(currentContext)) {
+		const targetArray = currentContext;
+		if (/^\d+$/.test(segmentRaw)) {
+			const index = Number.parseInt(segmentRaw, 10);
+			nextContext = index < targetArray.length ? targetArray[index] : undefined;
+		} else if (segmentRaw.startsWith('[?') && segmentRaw.endsWith(']')) {
+			const filterMatch = segmentRaw.match(
+				/^\[\?([a-zA-Z0-9_:]+)='([^']*)'\]$/,
+			);
+			if (filterMatch) {
+				const filterKey = filterMatch[1];
+				const filterValue = filterMatch[2];
+				const foundElement = targetArray.find(
+					(item) =>
+						typeof item === 'object' &&
+						item !== null &&
+						_.get(item, filterKey) === filterValue,
+				);
+				nextContext = foundElement;
+			} else {
+				nextContext = undefined;
+			}
+		} else if (
+			targetArray.length > 0 &&
+			typeof targetArray[0] === 'object' &&
+			targetArray[0] !== null
+		) {
+			const propertyOfFirstItem = _.get(targetArray[0], segmentRaw);
+			return getDeepFhirPathValue(
+				propertyOfFirstItem,
+				remainingSegments,
+				defaultValue,
+			);
+		} else {
+			nextContext = undefined;
+		}
+	} else {
+		if (remainingSegments.length > 0 && remainingSegments[0].startsWith('[?')) {
+			const arrayFromObject = _.get(currentContext, segmentRaw);
+			const filterSegment = remainingSegments[0];
+			const actualRemainingSegments = remainingSegments.slice(1);
+			return getDeepFhirPathValue(
+				arrayFromObject,
+				[filterSegment, ...actualRemainingSegments],
+				defaultValue,
+			);
+		}
+		nextContext = _.get(currentContext, segmentRaw);
+	}
+	return getDeepFhirPathValue(nextContext, remainingSegments, defaultValue);
+}
 
 export function getValue<T>(
-	obj: Record<string, unknown>,
+	obj: Record<string, unknown> | any[] | undefined | null,
 	path: string,
-	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	defaultValue?: any,
 ): T | undefined {
-	return _.get(obj, path, defaultValue) as T;
+	if (obj === undefined || obj === null) {
+		return defaultValue as T | undefined;
+	}
+	if (typeof path !== 'string' || !path) {
+		return defaultValue as T | undefined;
+	}
+
+	const segments = parsePathSegments(path);
+	if (!segments || segments.length === 0) {
+		if (!path.includes('.') && !path.includes('[')) {
+			return _.get(obj, path, defaultValue) as T | undefined;
+		}
+		// console.warn(`[getValueByPath] Path parser returned no segments for non-trivial path: '${path}'.`);
+		return defaultValue as T | undefined;
+	}
+	return getDeepFhirPathValue(obj, segments, defaultValue) as T | undefined;
 }

--- a/src/utils/parseFhirStored.ts
+++ b/src/utils/parseFhirStored.ts
@@ -1,0 +1,72 @@
+export function parseFhirStoredValue(
+	value: string | null,
+	fhirType: string | null,
+): any {
+	if (value === null || fhirType === null) return undefined;
+
+	const lowerType = fhirType.toLowerCase();
+	try {
+		switch (lowerType) {
+			case 'boolean':
+				return value.toLowerCase() === 'true';
+			case 'integer':
+			case 'positiveint':
+			case 'unsignedint':
+				return Number.parseInt(value, 10);
+			case 'decimal':
+				return Number.parseFloat(value);
+			// Tipos string já são string
+			case 'date':
+			case 'datetime':
+			case 'instant':
+			case 'time':
+			case 'string':
+			case 'code':
+			case 'id':
+			case 'markdown':
+			case 'uri':
+			case 'url':
+			case 'canonical':
+			case 'oid':
+			case 'uuid':
+				return value;
+			// Tipos complexos armazenados como JSON string
+			case 'address':
+			case 'annotation':
+			case 'attachment':
+			case 'codeableconcept':
+			case 'coding':
+			case 'contactdetail':
+			case 'contactpoint':
+			case 'contributor':
+			case 'datarequirement':
+			case 'humanname':
+			case 'identifier':
+			case 'money':
+			case 'parameterdefinition':
+			case 'period':
+			case 'quantity':
+			case 'range':
+			case 'ratio':
+			case 'reference':
+			case 'relatedartifact':
+			case 'sampleddata':
+			case 'signature':
+			case 'timing':
+			case 'triggerdefinition':
+			case 'usagecontext':
+				return JSON.parse(value);
+			default:
+				console.warn(
+					`[parseFhirStoredValue] Unhandled FHIR type '${fhirType}' for value '${value}'. Returning as string.`,
+				);
+				return value;
+		}
+	} catch (e) {
+		console.error(
+			`[parseFhirStoredValue] Error parsing value '${value}' for FHIR type '${fhirType}':`,
+			e,
+		);
+		return undefined; // Erro ao parsear
+	}
+}

--- a/src/utils/parsePathSegments.ts
+++ b/src/utils/parsePathSegments.ts
@@ -1,0 +1,66 @@
+/**
+ * Analisa uma string de caminho FHIR em segmentos lógicos.
+ * Exemplos:
+ * - "identifier.use" -> ["identifier", "use"]
+ * - "identifier[0].use" -> ["identifier", "0", "use"]
+ * - "extension[?url='...'].valueString" -> ["extension", "[?url='...']", "valueString"]
+ * - "meta.profile[0]" -> ["meta", "profile", "0"]
+ */
+export function parsePathSegments(path: string): string[] {
+	const segments: string[] = [];
+	if (!path || typeof path !== 'string') {
+		return segments;
+	}
+
+	let currentSegment = '';
+	let inBracketDepth = 0;
+
+	for (let i = 0; i < path.length; i++) {
+		const char = path[i];
+
+		if (char === '.' && inBracketDepth === 0) {
+			if (currentSegment) {
+				segments.push(currentSegment);
+			}
+			currentSegment = '';
+		} else if (char === '[') {
+			if (inBracketDepth === 0 && currentSegment) {
+				segments.push(currentSegment);
+				currentSegment = '';
+			}
+			currentSegment += char;
+			inBracketDepth++;
+		} else if (char === ']') {
+			currentSegment += char;
+			inBracketDepth = Math.max(0, inBracketDepth - 1);
+			if (inBracketDepth === 0) {
+				segments.push(currentSegment);
+				currentSegment = '';
+				if (i + 1 < path.length && path[i + 1] === '.') {
+					i++;
+				}
+			}
+		} else {
+			currentSegment += char;
+		}
+	}
+
+	if (currentSegment) {
+		segments.push(currentSegment);
+	}
+
+	// Ex: "[0]" se torna "0". Filtros como "[?url='...']" são mantidos.
+	return segments
+		.map((seg) => {
+			if (seg.startsWith('[') && seg.endsWith(']')) {
+				const inner = seg.substring(1, seg.length - 1);
+				if (/^\d+$/.test(inner)) {
+					return inner;
+				}
+				// Mantém filtros ou outros conteúdos de colchetes intactos (ex: "[?url='...']")
+				return seg;
+			}
+			return seg;
+		})
+		.filter((s) => s && s.length > 0); // Remove segmentos vazios
+}

--- a/src/utils/setValueByPath.ts
+++ b/src/utils/setValueByPath.ts
@@ -1,9 +1,215 @@
 import _ from 'lodash';
+import { parsePathSegments } from './parsePathSegments';
 
-export function setValue<T>(
+export interface SdElement {
+	path: string;
+	max?: string | null;
+}
+
+function findElementDefinitionByFullPath(
+	fullPath: string,
+	allSdElements: SdElement[],
+): SdElement | undefined {
+	let element = allSdElements.find((el) => el.path === fullPath);
+	if (element) return element;
+
+	const pathWithoutIndices = fullPath.replace(/\[\d+\]/g, '');
+	if (pathWithoutIndices !== fullPath) {
+		element = allSdElements.find((el) => el.path === pathWithoutIndices);
+	}
+	return element;
+}
+
+function setDeepFhirPath(
+	currentContextOrArray: any,
+	segments: string[],
+	valueToSet: any,
+	allSdElements: SdElement[],
+	currentFullPathPrefix: string,
+): void {
+	if (segments.length === 0) return;
+
+	const segmentRaw = segments[0];
+	const remainingSegments = segments.slice(1);
+
+	if (Array.isArray(currentContextOrArray)) {
+		const targetArray = currentContextOrArray;
+		let itemForRecursion: any;
+		let nextPathPrefixWithIndex = currentFullPathPrefix;
+
+		if (/^\d+$/.test(segmentRaw)) {
+			const indexToOperateOn = Number.parseInt(segmentRaw, 10);
+			nextPathPrefixWithIndex = `${currentFullPathPrefix}[${indexToOperateOn}]`;
+			while (targetArray.length <= indexToOperateOn) {
+				targetArray.push(remainingSegments.length === 0 ? null : {});
+			}
+
+			if (remainingSegments.length === 0) {
+				targetArray[indexToOperateOn] = valueToSet;
+			} else {
+				itemForRecursion = targetArray[indexToOperateOn];
+				if (typeof itemForRecursion !== 'object' || itemForRecursion === null) {
+					itemForRecursion = {};
+					targetArray[indexToOperateOn] = itemForRecursion;
+				}
+				setDeepFhirPath(
+					itemForRecursion,
+					remainingSegments,
+					valueToSet,
+					allSdElements,
+					nextPathPrefixWithIndex,
+				);
+			}
+		} else if (segmentRaw.startsWith('[?') && segmentRaw.endsWith(']')) {
+			const filterMatch = segmentRaw.match(
+				/^\[\?([a-zA-Z0-9_:]+)='([^']*)'\]$/,
+			);
+			if (filterMatch) {
+				const filterKey = filterMatch[1];
+				const filterValue = filterMatch[2];
+				let foundElement = targetArray.find(
+					(item) =>
+						typeof item === 'object' &&
+						item !== null &&
+						_.get(item, filterKey) === filterValue,
+				);
+				if (!foundElement) {
+					foundElement = { [filterKey]: filterValue };
+					targetArray.push(foundElement);
+				}
+				setDeepFhirPath(
+					foundElement,
+					remainingSegments,
+					valueToSet,
+					allSdElements,
+					`${currentFullPathPrefix}${segmentRaw}`,
+				);
+			} else {
+				/* Filtro malformado */
+				console.error(
+					`[setValueByPath] Filter segment '${segmentRaw}' malformed. Path: ${currentFullPathPrefix}${segmentRaw}. This may indicate an issue with path parsing or structure.`,
+				);
+			}
+		} else {
+			// Segmento é nome de propriedade (ex: "use") a ser aplicado a elementos do array
+			if (targetArray.length === 0 && segments.length > 0) {
+				const newArrayItem = {};
+				targetArray.push(newArrayItem);
+				setDeepFhirPath(
+					newArrayItem,
+					segments,
+					valueToSet,
+					allSdElements,
+					`${currentFullPathPrefix}[0]`,
+				);
+			} else {
+				for (let i = 0; i < targetArray.length; i++) {
+					if (typeof targetArray[i] === 'object' && targetArray[i] !== null) {
+						setDeepFhirPath(
+							targetArray[i],
+							segments.slice(),
+							valueToSet,
+							allSdElements,
+							`${currentFullPathPrefix}[${i}]`,
+						);
+					}
+				}
+			}
+		}
+		return;
+	}
+
+	const currentObject = currentContextOrArray;
+	const propertyName = segmentRaw; // Ex: "meta", "profile", "identifier", "type", "coding", "use"
+
+	if (propertyName.startsWith('[?') && propertyName.endsWith(']')) {
+		console.error(
+			`[setValueByPath] Filter segment '${propertyName}' encountered in an object context. Path: ${currentFullPathPrefix}.${propertyName}. This may indicate an issue with path parsing or structure.`,
+		);
+		return;
+	}
+
+	const fullPathToProperty = currentFullPathPrefix
+		? `${currentFullPathPrefix}.${propertyName}`
+		: propertyName;
+
+	if (remainingSegments.length === 0) {
+		_.set(currentObject, propertyName, valueToSet);
+	} else {
+		if (
+			!_.has(currentObject, propertyName) ||
+			(typeof _.get(currentObject, propertyName) !== 'object' &&
+				!Array.isArray(_.get(currentObject, propertyName)))
+		) {
+			const elementDefForProperty = findElementDefinitionByFullPath(
+				fullPathToProperty,
+				allSdElements,
+			);
+			let createAsArray = false;
+			if (elementDefForProperty) {
+				createAsArray =
+					elementDefForProperty.max === '*' ||
+					elementDefForProperty.max === null ||
+					(elementDefForProperty.max != null &&
+						Number.parseInt(elementDefForProperty.max, 10) > 1);
+			} else {
+				if (
+					[
+						'coding',
+						'identifier',
+						'extension',
+						'name',
+						'telecom',
+						'contact',
+						'entry',
+						'link',
+						'item',
+						'profile',
+					].includes(propertyName)
+				) {
+					createAsArray = true;
+				}
+				// console.warn(`[setValueByPath] SD element for '${fullPathToProperty}' not found. Defaulting structure for '${propertyName}' (array: ${createAsArray}).`);
+			}
+			_.set(currentObject, propertyName, createAsArray ? [] : {});
+		}
+		setDeepFhirPath(
+			_.get(currentObject, propertyName),
+			remainingSegments,
+			valueToSet,
+			allSdElements,
+			fullPathToProperty,
+		);
+	}
+}
+
+export function setValue(
 	obj: Record<string, unknown>,
-	path: string,
-	value: T,
-): T | undefined {
-	return _.set(obj, path, value) as T;
+	relativePath: string,
+	value: any,
+	allSdElements: SdElement[],
+	resourceType: string,
+): void {
+	if (!obj || typeof obj !== 'object') {
+		// console.error('[setValueByPath] Target object is invalid.');
+		return;
+	}
+	if (typeof relativePath !== 'string' || !relativePath) {
+		return;
+	}
+
+	const segments = parsePathSegments(relativePath);
+	if (!segments || segments.length === 0) {
+		if (
+			!relativePath.includes('.') &&
+			!relativePath.includes('[') &&
+			relativePath.length > 0
+		) {
+			_.set(obj, relativePath, value);
+		} else {
+			// console.warn(`[setValueByPath] Path parser gave no segments for: '${relativePath}'.`);
+		}
+		return;
+	}
+	setDeepFhirPath(obj, segments, value, allSdElements, resourceType);
 }

--- a/src/utils/transformation.ts
+++ b/src/utils/transformation.ts
@@ -1,0 +1,193 @@
+import {
+	format as formatDate,
+	isValid as isValidDate,
+	parse as parseDate,
+} from 'date-fns';
+import { getValue } from './getValueByPath';
+
+export interface TransformationContext {
+	sourceItem?: any;
+}
+export type TransformationResult = {
+	success: boolean;
+	value?: any;
+	message?: string;
+};
+export type TransformationFunction = (
+	value: any,
+	details: any | null | undefined,
+	context?: TransformationContext,
+) => TransformationResult;
+
+export type ValidationFunction = (
+	value: any,
+	details: any | null | undefined,
+	context?: TransformationContext,
+) => string | null;
+
+export const transformationRegistry = new Map<string, TransformationFunction>();
+export const validationRegistry = new Map<string, ValidationFunction>();
+
+// Exemplo: Transformação DATE_FORMAT
+const transformDateFormat: TransformationFunction = (value, details) => {
+	if (!details?.inputFormat || !details.outputFormat)
+		return { success: false, message: 'Invalid details for DATE_FORMAT' };
+	if (typeof value !== 'string' || !value)
+		return { success: true, value: value };
+	try {
+		const parsedDate = parseDate(value, details.inputFormat, new Date());
+		if (!isValidDate(parsedDate))
+			return {
+				success: false,
+				message: `Failed to parse date '${value}' with format '${details.inputFormat}'`,
+			};
+		return {
+			success: true,
+			value: formatDate(parsedDate, details.outputFormat),
+		};
+	} catch (e: any) {
+		return { success: false, message: `Error formatting date: ${e.message}` };
+	}
+};
+
+// Exemplo: Transformação STRING_CASE
+const transformStringCase: TransformationFunction = (value, details) => {
+	if (typeof value !== 'string') return { success: true, value: value };
+	const caseType = details?.case?.toLowerCase();
+	if (caseType === 'upper')
+		return { success: true, value: value.toUpperCase() };
+	if (caseType === 'lower')
+		return { success: true, value: value.toLowerCase() };
+	return {
+		success: false,
+		message: 'Invalid details for STRING_CASE (expected {case: "upper|lower"})',
+	};
+};
+
+// Exemplo: Transformação DEFAULT_VALUE (Precisa ser tratada um pouco diferente no fluxo principal)
+const transformDefaultValue: TransformationFunction = (value, details) => {
+	// A lógica principal verificará se value é nulo antes de chamar esta.
+	// Esta função é chamada apenas para obter o valor padrão.
+	// biome-ignore lint/suspicious/noPrototypeBuiltins: <explanation>
+	if (details?.hasOwnProperty('value')) {
+		return { success: true, value: details.value };
+	}
+	return {
+		success: false,
+		message: "Missing 'value' in details for DEFAULT_VALUE",
+	};
+};
+
+// Exemplo: Transformação CODE_LOOKUP
+const transformCodeLookup: TransformationFunction = (value, details) => {
+	if (!details?.map || typeof details.map !== 'object')
+		return {
+			success: false,
+			message: 'Invalid "map" object in details for CODE_LOOKUP',
+		};
+	const mappedValue = details.map[String(value)];
+	if (mappedValue !== undefined) return { success: true, value: mappedValue };
+	// biome-ignore lint/suspicious/noPrototypeBuiltins: <explanation>
+	if (details.hasOwnProperty('defaultValue'))
+		return { success: true, value: details.defaultValue };
+	return {
+		success: false,
+		message: `Value '${value}' not found in CODE_LOOKUP map and no defaultValue provided`,
+	};
+};
+
+// Exemplo: Transformação CONCATENATE (precisa do contexto)
+const transformConcatenate: TransformationFunction = (
+	value,
+	details,
+	context,
+) => {
+	if (
+		!details?.fieldsToConcat ||
+		!Array.isArray(details.fieldsToConcat) ||
+		!context?.sourceItem
+	) {
+		return {
+			success: false,
+			message: 'Invalid details or missing sourceItem for CONCATENATE',
+		};
+	}
+	const separator = details.separator ?? '';
+	try {
+		const valuesToConcat = details.fieldsToConcat.map((fieldPath: string) => {
+			const val = getValue(context.sourceItem, fieldPath); // Usa getValue do utils
+			return val !== null && val !== undefined ? String(val) : '';
+		});
+		return { success: true, value: valuesToConcat.join(separator) };
+	} catch (e: any) {
+		return {
+			success: false,
+			message: `Error during CONCATENATE: ${e.message}`,
+		};
+	}
+};
+
+// Exemplo: Validação REQUIRED
+const validateRequired: ValidationFunction = (value, details) => {
+	if (value === null || value === undefined || String(value).trim() === '') {
+		return 'Value is required but was missing or empty.';
+	}
+	return null;
+};
+
+// Exemplo: Validação REGEX
+const validateRegex: ValidationFunction = (value, details) => {
+	if (!details?.pattern) return 'Configuration error: Missing regex pattern.';
+	if (value === null || value === undefined) return null; // Não valida nulos
+	try {
+		if (!new RegExp(details.pattern).test(String(value))) {
+			return (
+				details.message ||
+				`Value '${value}' does not match pattern /${details.pattern}/.`
+			);
+		}
+		return null;
+	} catch (e: any) {
+		return `Configuration error: Invalid regex pattern /${details.pattern}/ (${e.message}).`;
+	}
+};
+
+// Exemplo: Validação MIN_LENGTH
+const validateMinLength: ValidationFunction = (value, details) => {
+	if (details?.min === undefined || typeof details.min !== 'number')
+		return 'Configuration error: Missing/invalid "min" number.';
+	if (value === null || value === undefined) return null;
+	if (String(value).length < details.min)
+		return `Value length (${String(value).length}) is less than minimum required (${details.min}).`;
+	return null;
+};
+
+// Exemplo: Validação VALUESET (Placeholder)
+const validateValueSet: ValidationFunction = (value, details) => {
+	if (!details?.valueSetUrl)
+		return 'Configuration error: Missing ValueSet URL.';
+	if (value === null || value === undefined) return null;
+	console.warn(
+		`[Validation] VALUESET validation for code '${value}' against '${details.valueSetUrl}' is NOT YET IMPLEMENTED.`,
+	);
+	// TODO: Implementar lógica real de validação (cache ou $validate-code)
+	return null;
+};
+
+// Transformações
+transformationRegistry.set('FORMAT_DATE', transformDateFormat);
+transformationRegistry.set('STRING_CASE', transformStringCase);
+transformationRegistry.set('DEFAULT_VALUE', transformDefaultValue);
+transformationRegistry.set('CODE_LOOKUP', transformCodeLookup);
+transformationRegistry.set('CONCATENATE', transformConcatenate);
+
+// Validações
+validationRegistry.set('REQUIRED', validateRequired);
+validationRegistry.set('REGEX', validateRegex);
+validationRegistry.set('MIN_LENGTH', validateMinLength);
+validationRegistry.set('VALUESET', validateValueSet);
+
+console.log(
+	`Registered ${transformationRegistry.size} transformation functions.`,
+);
+console.log(`Registered ${validationRegistry.size} validation functions.`);

--- a/src/utils/validateValue.ts
+++ b/src/utils/validateValue.ts
@@ -1,0 +1,94 @@
+export function validateValue(
+	value: any,
+	type: string | null | undefined,
+	details: any | null | undefined,
+): string | null {
+	if (!type) return null; // Sem validação
+
+	try {
+		switch (type.toUpperCase()) {
+			case 'REQUIRED':
+				if (
+					value === null ||
+					value === undefined ||
+					String(value).trim() === ''
+				) {
+					return 'Value is required but was missing or empty.';
+				}
+				return null; // Válido
+
+			case 'REGEX':
+				if (!details?.pattern) {
+					console.warn(`[Validation] Missing 'pattern' in details for REGEX`);
+					return 'Configuration error: Missing regex pattern.';
+				}
+				if (value === null || value === undefined) return null; // Não valida nulos (use REQUIRED para isso)
+				if (!new RegExp(details.pattern).test(String(value))) {
+					return (
+						details.message ||
+						`Value '${value}' does not match pattern /${details.pattern}/.`
+					);
+				}
+				return null; // Válido
+
+			case 'MIN_LENGTH':
+				if (!details || typeof details.min !== 'number') {
+					console.warn(
+						`[Validation] Missing/invalid 'min' number in details for MIN_LENGTH`,
+					);
+					return 'Configuration error: Missing min length.';
+				}
+				if (value === null || value === undefined) return null;
+				if (String(value).length < details.min) {
+					return `Value length (${String(value).length}) is less than minimum required (${details.min}).`;
+				}
+				return null; // Válido
+
+			case 'MAX_LENGTH':
+				if (!details || typeof details.max !== 'number') {
+					console.warn(
+						`[Validation] Missing/invalid 'max' number in details for MAX_LENGTH`,
+					);
+					return 'Configuration error: Missing max length.';
+				}
+				if (value === null || value === undefined) return null;
+				if (String(value).length > details.max) {
+					return `Value length (${String(value).length}) exceeds maximum allowed (${details.max}).`;
+				}
+				return null; // Válido
+
+			case 'VALUESET': {
+				if (!details?.valueSetUrl) {
+					console.warn(
+						`[Validation] Missing 'valueSetUrl' in details for VALUESET`,
+					);
+					return 'Configuration error: Missing ValueSet URL.';
+				}
+				if (value === null || value === undefined) return null; // Não valida nulos
+
+				// --- LÓGICA DE VALIDAÇÃO DE VALUESET (Placeholder) ---
+				// TODO: Implementar busca no cache local ou chamada à API $validate-code
+				const isValidCode = true; // <<-- SUBSTITUIR PELA LÓGICA REAL
+				const valueSetUrl = details.valueSetUrl;
+				console.warn(
+					`[Validation] VALUESET validation for code '${value}' against '${valueSetUrl}' is NOT YET IMPLEMENTED. Assuming valid for now.`,
+				);
+				if (!isValidCode) {
+					// A força ('required', 'extensible', etc.) poderia influenciar se isso é um erro hard ou warning
+					return `Value '${value}' is not valid according to ValueSet '${valueSetUrl}'.`;
+				}
+				// --- Fim do Placeholder ---
+				return null; // Válido (no placeholder)
+			}
+
+			default:
+				console.warn(`[Validation] Unsupported validation type: ${type}`);
+				return `Configuration error: Unsupported validation type '${type}'.`; // Erro de configuração
+		}
+	} catch (error: any) {
+		console.error(
+			`[Validation] Error during validation type ${type} for value '${value}': ${error.message}`,
+		);
+		return `Internal error during validation: ${error.message}`;
+	}
+}

--- a/tests/patient.csv
+++ b/tests/patient.csv
@@ -1,3 +1,3 @@
 id_paciente,nome_completo,data_nascimento,genero
-PAT001,João da Silva,1985-04-15,male
-PAT002,Maria Oliveira,1992-09-22,female
+1,Jo,1985-04-15,M
+2,Maria Oliveira,27/04/2025,F


### PR DESCRIPTION
This pull request introduces several updates to improve validation, transformation, and dependency management in the project. Key changes include enhancements to field mapping in the `prisma` schema, updates to seed scripts for better data mapping and validation, and the addition of new dependencies to support these functionalities.

### Validation and Transformation Enhancements:
* Updated the `FieldMapping` model in `prisma/schema.prisma` to include `validationType` and `validationDetails` fields for more robust data validation. The `transformationType` field was also updated to use an enum for better type safety.

* Enhanced the `seed.ts` script to include detailed validation and transformation logic for mappings, such as regex validation for CPF, date format transformations, and value set validation for gender. New mappings were added for both CSV and JSON sources. [[1]](diffhunk://#diff-13326c178007fc61a910b587dff0f35f80ac9673dbe101f1fa665961a6878491L9-R172) [[2]](diffhunk://#diff-13326c178007fc61a910b587dff0f35f80ac9673dbe101f1fa665961a6878491L62) [[3]](diffhunk://#diff-13326c178007fc61a910b587dff0f35f80ac9673dbe101f1fa665961a6878491L76-R198) [[4]](diffhunk://#diff-13326c178007fc61a910b587dff0f35f80ac9673dbe101f1fa665961a6878491L88-R323)

### Dependency Management:
* Added new dependencies in `package.json` and `pnpm-lock.yaml`, including `@fastify/multipart` and `date-fns-tz`, to support multipart handling and timezone-aware date processing. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R33-R36) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R22) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR624-R631)

* Removed and re-added `@types/stream-json` in `pnpm-lock.yaml` to align with updated requirements. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R22) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR57-R59)

### Configuration Updates:
* Updated the `biome.json` linter configuration to disable the `noExplicitAny` rule under the "suspicious" category.